### PR TITLE
Avoid check on MZ_OPEN_MODE_READWRITE (being composed of READ | WRITE)

### DIFF
--- a/src/excel/xlsx/zip_file.cpp
+++ b/src/excel/xlsx/zip_file.cpp
@@ -133,8 +133,10 @@ int32_t mz_stream_duckdb_seek(void *stream, int64_t offset, int32_t origin) {
 
 int32_t mz_stream_duckdb_close(void *stream) {
 	auto &self = *reinterpret_cast<mz_stream_duckdb *>(stream);
-	self.handle->Sync();
 	self.handle->Close();
+	self.handle->~FileHandle();
+	self.handle = nullptr;
+	self.last_error.clear();
 	return MZ_OK;
 }
 
@@ -156,10 +158,10 @@ void mz_stream_duckdb_delete(void **stream) {
 	}
 	auto &self = *reinterpret_cast<mz_stream_duckdb *>(*stream);
 	if (self.handle) {
-		self.handle->Sync();
 		self.handle->Close();
 		self.handle->~FileHandle();
 		self.handle = nullptr;
+		self.last_error.clear();
 	}
 	delete reinterpret_cast<mz_stream_duckdb *>(*stream);
 	*stream = nullptr;

--- a/src/excel/xlsx/zip_file.cpp
+++ b/src/excel/xlsx/zip_file.cpp
@@ -66,9 +66,6 @@ int32_t mz_stream_duckdb_open(void *stream, const char *path, int32_t mode) {
 	if (mode & MZ_OPEN_MODE_WRITE) {
 		flags |= FileFlags::FILE_FLAGS_WRITE;
 	}
-	if (mode & MZ_OPEN_MODE_READWRITE) {
-		flags |= FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_READ;
-	}
 	if (mode & MZ_OPEN_MODE_APPEND) {
 		flags |= FileFlags::FILE_FLAGS_APPEND;
 	}


### PR DESCRIPTION
I checked implementation MZ_OPEN_MODE_READWRITE is a combination of READ bit and WRITE bit ([example](https://pub.dev/documentation/flutter_minizip_ffi_bindings/latest/flutter_minizip_ffi_bindings/MZ_OPEN_MODE_READWRITE-constant.html, 1 | 2 = 3) 

That means that MZ_OPEN_MODE_READWRITE & flags will be true if EITHER read or write are set, this in turns make file opened for reading with a flags connected to writing.

This I think trigger failures like:
```
================================================================================
Query unexpectedly failed (D:/a/duckdb/duckdb/build/release/_deps/excel_extension_fc-src/test/sql/excel/xlsx/read_sparse.test:31)
================================================================================
select * FROM read_xlsx('test/data/xlsx/sparse.xlsx', header = false, range = 'W801:W801');
================================================================================
Actual result:
IO Error: Cannot open file "test/data/xlsx/sparse.xlsx": The process cannot access the file because it is being used by another process.
```
and problem while using in duckdb-wasm (that due to weird file system requires either write or read permissions).