### PR TITLE
Upgrade CI, fix warning when opening through MS-Excel, fix cast vector validity not resetting between columns

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -14,20 +14,20 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.2.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.2.1
     with:
-      duckdb_version: v1.2.0
-      ci_tools_version: v1.2.0
+      duckdb_version: v1.2.1
+      ci_tools_version: v1.2.1
       extension_name: excel
 
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.2.0
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.2.1
     secrets: inherit
     with:
-      duckdb_version: v1.2.0
-      ci_tools_version: v1.2.0
+      duckdb_version: v1.2.1
+      ci_tools_version: v1.2.1
       extension_name: excel
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}

--- a/src/excel/include/xlsx/xlsx_writer.hpp
+++ b/src/excel/include/xlsx/xlsx_writer.hpp
@@ -37,8 +37,9 @@ private:
 	void WriteWorkbook();
 	void WriteRels();
 	void WriteContentTypes();
+	void WriteDocProps();
 	void WriteSharedStrings();
-	void WriteProps();
+	void WritePackageRels();
 
 	class XLSXSheet {
 	public:
@@ -147,7 +148,7 @@ inline void XLXSWriter::EndSheet() {
 }
 
 inline void XLXSWriter::WriteNumberCell(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" t=\"n\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 
@@ -172,7 +173,7 @@ inline void XLXSWriter::WriteInlineStringCell(const string_t &value) {
 }
 
 inline void XLXSWriter::WriteDateCell(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" t=\"n\" s=\"1\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"1\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 
@@ -180,7 +181,7 @@ inline void XLXSWriter::WriteDateCell(const string_t &value) {
 }
 
 inline void XLXSWriter::WriteTimeCell(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" t=\"n\" s=\"3\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"3\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 
@@ -188,7 +189,7 @@ inline void XLXSWriter::WriteTimeCell(const string_t &value) {
 }
 
 inline void XLXSWriter::WriteTimestampCell(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" t=\"n\" s=\"4\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"4\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 
@@ -196,7 +197,7 @@ inline void XLXSWriter::WriteTimestampCell(const string_t &value) {
 }
 
 inline void XLXSWriter::WriteTimestampCellNoMilliseconds(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" t=\"n\" s=\"2\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"2\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 
@@ -233,12 +234,12 @@ inline void XLXSWriter::EndRow() {
 
 inline void XLXSWriter::Finish() {
 
+	WriteContentTypes();
+	WritePackageRels();
 	WriteWorkbook();
 	WriteRels();
 	WriteStyles();
-	WriteSharedStrings();
-	WriteProps();
-	WriteContentTypes();
+	WriteDocProps();
 
 	// Done!
 	stream.Finalize();
@@ -281,6 +282,13 @@ inline void XLXSWriter::WriteStyles() {
 			<numFmt formatCode="dd/mm/yyyy\ hh:mm:ss.000" numFmtId="168"/>
 			<numFmt formatCode="&quot;TRUE&quot;;&quot;TRUE&quot;;&quot;FALSE&quot;" numFmtId="169"/>
 		</numFmts>
+		<fonts count="1">
+			<font>
+				<name val="Arial"/>
+				<family val="2"/>
+				<sz val="12"/>
+			</font>
+		</fonts>
 		<fills count="1">
 			<fill>
 				<patternFill patternType="none"/>
@@ -323,22 +331,11 @@ inline void XLXSWriter::WriteContentTypes() {
 	    R"(<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">)"
 	    R"(<Default Extension="xml" ContentType="application/xml"/>)"
 	    R"(<Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>)"
-	    R"(<Default Extension="jpeg" ContentType="image/jpg"/>)"
-	    R"(<Default Extension="png" ContentType="image/png"/>)"
-	    R"(<Default Extension="bmp" ContentType="image/bmp"/>)"
-	    R"(<Default Extension="gif" ContentType="image/gif"/>)"
-	    R"(<Default Extension="tif" ContentType="image/tif"/>)"
-	    R"(<Default Extension="pdf" ContentType="application/pdf"/>)"
-	    R"(<Default Extension="mov" ContentType="application/movie"/>)"
-	    R"(<Default Extension="vml" ContentType="application/vnd.openxmlformats-officedocument.vmlDrawing"/>)"
-	    R"(<Default Extension="xlsx" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"/>)"
-	    R"(<Override PartName="/_rels/.rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>)"
 	    R"(<Override PartName="/docProps/core.xml" ContentType="application/vnd.openxmlformats-package.core-properties+xml"/>)"
 	    R"(<Override PartName="/docProps/app.xml" ContentType="application/vnd.openxmlformats-officedocument.extended-properties+xml"/>)"
 	    R"(<Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>)"
-	    R"(<Override PartName="/xl/_rels/workbook.xml.rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>)"
-	    R"(<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>)"
-	    R"(<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>)";
+		R"(<Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>)"
+	    R"(<Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>)";
 	static constexpr auto CONTENT_TYPES_XML_END = R"(</Types>)";
 
 	stream.BeginFile("[Content_Types].xml");
@@ -353,6 +350,38 @@ inline void XLXSWriter::WriteContentTypes() {
 	stream.Write(CONTENT_TYPES_XML_END);
 	stream.EndFile();
 }
+
+inline void XLXSWriter::WriteDocProps() {
+
+	stream.AddDirectory("docProps/");
+
+	static constexpr auto APP_PROPS_XML =
+	    R"(<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">)"
+	    R"(<Application>DuckDB</Application>)"
+	    R"(<TotalTime>0</TotalTime>)"
+	    R"(</Properties>)";
+
+	stream.BeginFile("docProps/app.xml");
+	stream.Write(ENCODING_FRAGMENT);
+	stream.Write(APP_PROPS_XML);
+	stream.EndFile();
+
+	static constexpr auto CORE_PROPS_XML =
+		R"(<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">)"
+		R"(<dcterms:created xsi:type="dcterms:W3CDTF">2024-11-15T13:37:00.00Z</dcterms:created>)"
+		R"(<dc:creator>DuckDB</dc:creator>)"
+		R"(<cp:lastModifiedBy>DuckDB</cp:lastModifiedBy>)"
+		R"(<dcterms:modified xsi:type="dcterms:W3CDTF">2024-11-15T13:37:00.00Z</dcterms:modified>)"
+		R"(<cp:revision>1</cp:revision>)"
+		R"(</cp:coreProperties>)";
+
+	stream.BeginFile("docProps/core.xml");
+	stream.Write(ENCODING_FRAGMENT);
+	stream.Write(CORE_PROPS_XML);
+	stream.EndFile();
+
+}
+
 
 inline void XLXSWriter::WriteRels() {
 	static constexpr auto WORKBOOK_REL_XML_START =
@@ -403,21 +432,7 @@ inline void XLXSWriter::WriteSharedStrings() {
 	stream.EndFile();
 }
 
-inline void XLXSWriter::WriteProps() {
-	static constexpr auto CORE_PROPS_XML =
-	    R"(<cp:coreProperties xmlns:cp="http://schemas.openxmlformats.org/package/2006/metadata/core-properties" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcmitype="http://purl.org/dc/dcmitype/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">)"
-	    R"(<dcterms:created xsi:type="dcterms:W3CDTF">2024-11-15T13:37:00.00Z</dcterms:created>)"
-	    R"(<dc:creator>DuckDB</dc:creator>)"
-	    R"(<cp:lastModifiedBy>DuckDB</cp:lastModifiedBy>)"
-	    R"(<dcterms:modified xsi:type="dcterms:W3CDTF">2024-11-15T13:37:00.00Z</dcterms:modified>)"
-	    R"(<cp:revision>1</cp:revision>)"
-	    R"(</cp:coreProperties>)";
-
-	static constexpr auto APP_PROPS_XML =
-	    R"(<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">)"
-	    R"(<Application>DuckDB</Application>)"
-	    R"(<TotalTime>0</TotalTime>)"
-	    R"(</Properties>)";
+inline void XLXSWriter::WritePackageRels() {
 
 	static constexpr auto ROOT_RELS =
 	    R"(<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">)"
@@ -430,16 +445,6 @@ inline void XLXSWriter::WriteProps() {
 	stream.BeginFile("_rels/.rels");
 	stream.Write(ENCODING_FRAGMENT);
 	stream.Write(ROOT_RELS);
-	stream.EndFile();
-
-	stream.BeginFile("docProps/core.xml");
-	stream.Write(ENCODING_FRAGMENT);
-	stream.Write(CORE_PROPS_XML);
-	stream.EndFile();
-
-	stream.BeginFile("docProps/app.xml");
-	stream.Write(ENCODING_FRAGMENT);
-	stream.Write(APP_PROPS_XML);
 	stream.EndFile();
 }
 

--- a/src/excel/xlsx/read_xlsx.cpp
+++ b/src/excel/xlsx/read_xlsx.cpp
@@ -577,10 +577,11 @@ static void TryCastTimestamp(XLSXGlobalState &state, bool ignore_errors, const i
 
 	// Then convert the double to a timestamp
 	const auto row_count = state.parser.GetChunk().size();
-	UnaryExecutor::Execute<double, timestamp_t>(state.cast_vec.data[0], target_col, row_count, [&](const double &input) {
-		const auto epoch_us = ExcelToEpochUS(input);
-		return Timestamp::FromEpochMicroSeconds(epoch_us);
-	});
+	UnaryExecutor::Execute<double, timestamp_t>(state.cast_vec.data[0], target_col, row_count,
+	                                            [&](const double &input) {
+		                                            const auto epoch_us = ExcelToEpochUS(input);
+		                                            return Timestamp::FromEpochMicroSeconds(epoch_us);
+	                                            });
 }
 
 static void Execute(ClientContext &context, TableFunctionInput &data, DataChunk &output) {

--- a/src/excel/xlsx/read_xlsx.cpp
+++ b/src/excel/xlsx/read_xlsx.cpp
@@ -440,7 +440,9 @@ public:
 	                         bool stop_at_empty)
 	    : archive(context, file_name), strings(BufferAllocator::Get(context)),
 	      parser(context, range, strings, stop_at_empty),
-	      buffer(make_unsafe_uniq_array_uninitialized<char>(BUFFER_SIZE)), cast_vec(LogicalType::DOUBLE) {
+	      buffer(make_unsafe_uniq_array_uninitialized<char>(BUFFER_SIZE)) {
+
+		cast_vec.Initialize(context, {LogicalType::DOUBLE});
 	}
 
 	ZipFileReader archive;
@@ -451,7 +453,7 @@ public:
 	XMLParseResult status = XMLParseResult::OK;
 
 	string cast_err;
-	Vector cast_vec;
+	DataChunk cast_vec;
 
 	atomic<idx_t> stream_pos = {0};
 	idx_t stream_len = 0;
@@ -543,11 +545,11 @@ static void TryCastFromString(XLSXGlobalState &state, bool ignore_errors, const 
 static void TryCastTime(XLSXGlobalState &state, bool ignore_errors, const idx_t col_idx, ClientContext &context,
                         Vector &target_col) {
 	// First cast it to a double
-	TryCastFromString(state, ignore_errors, col_idx, context, state.cast_vec);
+	TryCastFromString(state, ignore_errors, col_idx, context, state.cast_vec.data[0]);
 
 	// Then convert the double to a time
 	const auto row_count = state.parser.GetChunk().size();
-	UnaryExecutor::Execute<double, dtime_t>(state.cast_vec, target_col, row_count, [&](const double &input) {
+	UnaryExecutor::Execute<double, dtime_t>(state.cast_vec.data[0], target_col, row_count, [&](const double &input) {
 		const auto epoch_us = ExcelToEpochUS(input);
 		const auto stamp = Timestamp::FromEpochMicroSeconds(epoch_us);
 		return Timestamp::GetTime(stamp);
@@ -557,11 +559,11 @@ static void TryCastTime(XLSXGlobalState &state, bool ignore_errors, const idx_t 
 static void TryCastDate(XLSXGlobalState &state, bool ignore_errors, const idx_t col_idx, ClientContext &context,
                         Vector &target_col) {
 	// First cast it to a double
-	TryCastFromString(state, ignore_errors, col_idx, context, state.cast_vec);
+	TryCastFromString(state, ignore_errors, col_idx, context, state.cast_vec.data[0]);
 
 	// Then convert the double to a date
 	const auto row_count = state.parser.GetChunk().size();
-	UnaryExecutor::Execute<double, date_t>(state.cast_vec, target_col, row_count, [&](const double &input) {
+	UnaryExecutor::Execute<double, date_t>(state.cast_vec.data[0], target_col, row_count, [&](const double &input) {
 		const auto epoch_us = ExcelToEpochUS(input);
 		const auto stamp = Timestamp::FromEpochMicroSeconds(epoch_us);
 		return Timestamp::GetDate(stamp);
@@ -571,11 +573,11 @@ static void TryCastDate(XLSXGlobalState &state, bool ignore_errors, const idx_t 
 static void TryCastTimestamp(XLSXGlobalState &state, bool ignore_errors, const idx_t col_idx, ClientContext &context,
                              Vector &target_col) {
 	// First cast it to a double
-	TryCastFromString(state, ignore_errors, col_idx, context, state.cast_vec);
+	TryCastFromString(state, ignore_errors, col_idx, context, state.cast_vec.data[0]);
 
 	// Then convert the double to a timestamp
 	const auto row_count = state.parser.GetChunk().size();
-	UnaryExecutor::Execute<double, timestamp_t>(state.cast_vec, target_col, row_count, [&](const double &input) {
+	UnaryExecutor::Execute<double, timestamp_t>(state.cast_vec.data[0], target_col, row_count, [&](const double &input) {
 		const auto epoch_us = ExcelToEpochUS(input);
 		return Timestamp::FromEpochMicroSeconds(epoch_us);
 	});
@@ -645,7 +647,13 @@ static void Execute(ClientContext &context, TableFunctionInput &data, DataChunk 
 		if (source_type == target_type) {
 			// If the types are the same, reference the column
 			target_col.Reference(source_col);
-		} else if (xlsx_type == XLSXCellType::NUMBER && target_type == LogicalTypeId::TIME) {
+			continue;
+		}
+
+		// Clear the cast vector
+		gstate.cast_vec.Reset();
+
+		if (xlsx_type == XLSXCellType::NUMBER && target_type == LogicalTypeId::TIME) {
 			TryCastTime(gstate, options.ignore_errors, col_idx, context, target_col);
 		} else if (xlsx_type == XLSXCellType::NUMBER && target_type == LogicalTypeId::DATE) {
 			TryCastDate(gstate, options.ignore_errors, col_idx, context, target_col);

--- a/test/sql/excel/xlsx/cast_validity_reset.test
+++ b/test/sql/excel/xlsx/cast_validity_reset.test
@@ -1,0 +1,21 @@
+require excel
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+
+statement ok
+COPY (select NULL::DATE A, '2024-12-31'::DATE B) TO '__TEST_DIR__/double_date_null.xlsx' WITH(FORMAT xlsx, HEADER true);
+
+statement ok
+create or replace table testtable (
+    A DATE NULL,
+    B DATE NOT NULL,
+);
+
+statement ok
+COPY testtable FROM 'test.xlsx' (FORMAT xlsx);
+
+query II
+SELECT * FROM testtable
+----
+NULL	2024-12-31

--- a/test/sql/excel/xlsx/cast_validity_reset.test
+++ b/test/sql/excel/xlsx/cast_validity_reset.test
@@ -13,7 +13,7 @@ create or replace table testtable (
 );
 
 statement ok
-COPY testtable FROM 'test.xlsx' (FORMAT xlsx);
+COPY testtable FROM '__TEST_DIR__/test.xlsx' (FORMAT xlsx);
 
 query II
 SELECT * FROM testtable

--- a/test/sql/excel/xlsx/cast_validity_reset.test
+++ b/test/sql/excel/xlsx/cast_validity_reset.test
@@ -13,7 +13,7 @@ create or replace table testtable (
 );
 
 statement ok
-COPY testtable FROM '__TEST_DIR__/test.xlsx' (FORMAT xlsx);
+COPY testtable FROM '__TEST_DIR__/double_date_null.xlsx' (FORMAT xlsx);
 
 query II
 SELECT * FROM testtable


### PR DESCRIPTION
Upgrades the CI to v1.2.1 so that nightly builds are distributed properly.

I've now also got my hand on a copy of excel to verify that it's possible to open files written with DuckDB through the real excel without warnings. And well, turns out there were still a lot of edge cases that Microsofts excel gets hung up on, but they should be fixed now.

Closes #36
Closes #38
