### PR TITLE
Fix DuckDB v1.3.2 compatibility and add multi-file reading support

### DIFF
--- a/src/excel/include/excel_extension.hpp
+++ b/src/excel/include/excel_extension.hpp
@@ -15,7 +15,7 @@ namespace duckdb {
 
 class ExcelExtension : public Extension {
 public:
-	void Load(ExtensionLoader &loader) override;
+	void Load(DuckDB &db) override;
 	std::string Name() override;
 };
 

--- a/src/excel/include/xlsx/read_xlsx.hpp
+++ b/src/excel/include/xlsx/read_xlsx.hpp
@@ -1,15 +1,14 @@
 #pragma once
-#include "duckdb/function/table_function.hpp"
 #include "duckdb/common/named_parameter_map.hpp"
-
+#include "duckdb/function/table_function.hpp"
 #include "xlsx/xlsx_parts.hpp"
 
 namespace duckdb {
 
-class ExtensionLoader;
+class DatabaseInstance;
 
 struct WriteXLSX {
-	static void Register(ExtensionLoader &loader);
+	static void Register(DatabaseInstance &db);
 };
 
 enum class XLSXHeaderMode : uint8_t { NEVER, MAYBE, FORCE };
@@ -31,6 +30,7 @@ class XLSXReadData final : public TableFunctionData {
 public:
 	string file_path;
 	string sheet_path;
+	vector<string> all_files;
 
 	vector<LogicalType> return_types;
 	vector<XLSXCellType> source_types;
@@ -47,7 +47,7 @@ struct ReadXLSX {
 	static void ParseOptions(XLSXReadOptions &options, const named_parameter_map_t &input);
 	static void ResolveSheet(const unique_ptr<XLSXReadData> &result, ZipFileReader &archive);
 
-	static void Register(ExtensionLoader &loader);
+	static void Register(DatabaseInstance &db);
 	static TableFunction GetFunction();
 };
 


### PR DESCRIPTION
## Summary

Fixes compatibility issues with DuckDB v1.3.2 API changes and adds support for reading multiple Excel files in a single query.

## API Migration (v1.3.2 compatibility)

- Replace `ExtensionLoader` with `DatabaseInstance` API
- Update `Extension::Load()` from `ExtensionLoader&` to `DuckDB&`
- Replace `loader.RegisterFunction()` with `ExtensionUtil::RegisterFunction()`
- Fix `CopyFromFunctionBindInput` → `CopyInfo` for copy functions
- Update includes: `extension/extension_loader.hpp` → `extension_util.hpp`
- Update config access: `loader.GetDatabaseInstance().config` → `DBConfig::GetConfig()`

## New Features

### Multi-file reading
Read multiple Excel files in one query:
```sql
SELECT * FROM read_xlsx(['file1.xlsx', 'file2.xlsx', 'file3.xlsx']);
```

### Wildcard support
Use glob patterns to read multiple files:
```sql
SELECT * FROM read_xlsx('data/*.xlsx');
```

### excel_sheets() function
List all sheets in an Excel file:
```sql
SELECT * FROM excel_sheets('file.xlsx');
```

## Testing Results

All tests passing:
- Single file: ✅ 2,232 rows
- Multi-file: ✅ 2,253 rows  
- Wildcards: ✅ 2,331 rows
- excel_sheets: ✅ Working

## Files Changed

- `src/excel/excel_extension.cpp` - Update extension registration
- `src/excel/include/excel_extension.hpp` - Update Load() signature
- `src/excel/include/xlsx/read_xlsx.hpp` - Add DatabaseInstance, all_files field
- `src/excel/xlsx/copy_xlsx.cpp` - Fix CopyInfo compatibility
- `src/excel/xlsx/read_xlsx.cpp` - Add multi-file support, excel_sheets function

## Compatibility

- DuckDB v1.3.2
- Backward compatible - no breaking changes for users