### PR TITLE
ci: Skip CI for version bump commits

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -6,11 +6,9 @@ on:
   push:
   pull_request:
   workflow_dispatch:
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}-${{ github.base_ref || '' }}-${{ github.ref != 'refs/heads/main' || github.sha }}
   cancel-in-progress: true
-
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
@@ -19,12 +17,12 @@ jobs:
       duckdb_version: main
       ci_tools_version: main
       extension_name: excel
-
+    if: (github.event_name != 'push' || !contains(lower(join(github.event.commits.*.message, ' ')), 'bump to')) && (github.event_name != 'pull_request' || !contains(lower(github.event.pull_request.title), 'bump to'))
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.3.2
-    if: false # TODO: re-enable when switching back to latest stable
+    if: ((github.event_name != 'push' || !contains(lower(join(github.event.commits.*.message, ' ')), 'bump to')) && (github.event_name != 'pull_request' || !contains(lower(github.event.pull_request.title), 'bump to'))) && (false) # TODO: re-enable when switching back to latest stable
     secrets: inherit
     with:
       duckdb_version: v1.3.2


### PR DESCRIPTION
This PR adds a conditional skip to the CI workflow to avoid running builds and tests when the commit message or PR title contains "bump to".