### PR TITLE
Fix bug not writing Shared Strings file to xlsx ZIP.

### DIFF
--- a/src/excel/include/xlsx/xlsx_writer.hpp
+++ b/src/excel/include/xlsx/xlsx_writer.hpp
@@ -239,6 +239,7 @@ inline void XLXSWriter::Finish() {
 	WriteWorkbook();
 	WriteRels();
 	WriteStyles();
+	WriteSharedStrings();
 	WriteDocProps();
 
 	// Done!


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-excel/issues/52

`xlsx` ZIP files require a `xl/sharedStrings.xml` file in the ZIP archive. The code already existed to create this file, but the function was not called. This PR calls the function.

This allows files to be properly opened with OpenPyXL, in Apple Numbers, and a few other applications which were throwing an error due to the lack of this file existing.

I've also updated the submodule pointer to v1.4.3 for duckdb, which was necessary to compile properly. Here's the test code I used to verify it works:

```python
import os
import shutil
import duckdb
import zipfile

# Allow unsigned extensions at connection time
conn = duckdb.connect(config={'allow_unsigned_extensions': 'true'})
conn.execute("SET extension_directory='/home/my-user/projects/duckdb-excel/build/release/extension'")
conn.execute("LOAD excel")

conn.execute("COPY (SELECT 'test' as a, 123 as b) TO '/tmp/test.xlsx' (FORMAT xlsx, HEADER true)")

with zipfile.ZipFile('/tmp/test.xlsx') as z:
    files = z.namelist()
    for f in sorted(files):
        print(f)
    
    if 'xl/sharedStrings.xml' in files:
        print('\n\nSUCCESS: xl/sharedStrings.xml is present!')
        content = z.read('xl/sharedStrings.xml')
        print(f'Content: {content}')
    else:
        print('\n\nFAILED: xl/sharedStrings.xml is MISSING')

# Test reading with openpyxl
print('\n\n--- Testing with openpyxl ---')
try:
    from openpyxl import load_workbook
    wb = load_workbook('/tmp/test.xlsx')
    ws = wb.active
    print('OpenPyXL can read the file!')
    print('Data:', list(ws.values))
except Exception as e:
    print(f'OpenPyXL error: {e}')
```