### PR TITLE
feat: multi-sheet write via MODE 'append' / 'replace'

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ __Options__:
 | `header` | `BOOLEAN` | `false`   | Whether to write the column names as the first row in the sheet                      |
 | `sheet`| `VARCHAR` | `Sheet1`  | The name of the sheet in the xlsx file to write.                                     |
 | `sheet_row_limit` | `INTEGER` | `1048576` | The maximum number of rows in a sheet. An error is thrown if this limit is exceeded. |
+| `mode` | `VARCHAR` | `create` | How to handle the target file. `create` writes a fresh single-sheet xlsx (overwriting any existing file). `append` adds a new sheet to an existing xlsx (errors if a sheet with the same name already exists). `replace` overwrites a single sheet by name in an existing xlsx (errors if no sheet with that name is found). |
 
 __Example usage__:
 
@@ -81,6 +82,26 @@ __Example usage__:
 CREATE TABLE test AS SELECT * FROM (VALUES (1, 2), (3, 4)) AS t(a, b);
 COPY test TO 'test.xlsx' (format 'xlsx', header 'true');
 ```
+
+### Writing multiple sheets to one xlsx
+
+Successive `COPY` statements with `mode 'append'` add new sheets to the same workbook. The first call creates the file; subsequent calls add sheets. `mode 'replace'` overwrites a single named sheet, leaving every other sheet untouched.
+
+```sql
+COPY (SELECT 1 AS x, 'one'   AS y) TO 'multi.xlsx' (format 'xlsx', header true, sheet 'A');
+COPY (SELECT 2 AS x, 'two'   AS y) TO 'multi.xlsx' (format 'xlsx', header true, sheet 'B', mode 'append');
+COPY (SELECT 3 AS x, 'three' AS y) TO 'multi.xlsx' (format 'xlsx', header true, sheet 'C', mode 'append');
+
+-- Replace sheet B in place — sheets A and C are unchanged
+COPY (SELECT 999 AS x, 'replaced' AS y) TO 'multi.xlsx' (format 'xlsx', header true, sheet 'B', mode 'replace');
+```
+
+Notes:
+- `mode 'append'` against a path that doesn't exist yet falls back to `create`, so the first call in a multi-`COPY` sequence works the same way regardless of whether you pass `mode 'append'` or omit it.
+- `mode 'replace'` keeps the existing sheet's position, internal id, and file path stable, so external references in the workbook (charts, defined names, pivot caches) remain valid after the rewrite.
+- Appending into an xlsx authored by Excel, openpyxl, or another tool is supported: the existing workbook structure, styles, shared strings, and all unrelated sheets are preserved verbatim.
+- Use `mode 'append'` for adding sheets, `mode 'replace'` for overwriting one. Setting an invalid `mode` value raises an error at bind time.
+- `mode 'append'` and `mode 'replace'` only work for **local files**. They need to read the existing workbook and atomically swap a rebuilt copy back into place, which remote filesystems (`s3://`, `https://`, `gcs://`, `azure://`, …) don't support; using either against a remote path raises an error before the destination is touched. Write the workbook to a local path and upload it instead. (`mode 'create'` — the default — works with remote paths as usual, since it just writes a fresh file.)
 
 ## Type Conversions and Inference
 

--- a/src/excel/include/xlsx/parsers/styles_append_parser.hpp
+++ b/src/excel/include/xlsx/parsers/styles_append_parser.hpp
@@ -1,0 +1,118 @@
+#pragma once
+
+#include "xlsx/xml_parser.hpp"
+
+namespace duckdb {
+
+struct XLSXNumFmtEntry {
+	idx_t num_fmt_id;
+	string format_code;
+};
+
+struct XLSXCellXfEntry {
+	idx_t num_fmt_id;
+};
+
+class StylesAppendParser final : public XMLParser {
+public:
+	vector<XLSXNumFmtEntry> num_fmts;
+	vector<XLSXCellXfEntry> cell_xfs;
+
+protected:
+	void OnStartElement(const char *name, const char **atts) override;
+	void OnEndElement(const char *name) override;
+
+private:
+	enum class State : uint8_t { START, STYLESHEET, NUMFMTS, NUMFMT, CELLXFS, XF };
+	State state = State::START;
+};
+
+inline void StylesAppendParser::OnStartElement(const char *name, const char **atts) {
+	switch (state) {
+	case State::START:
+		if (MatchTag("styleSheet", name)) {
+			state = State::STYLESHEET;
+		}
+		break;
+	case State::STYLESHEET:
+		if (MatchTag("numFmts", name)) {
+			state = State::NUMFMTS;
+		} else if (MatchTag("cellXfs", name)) {
+			state = State::CELLXFS;
+		}
+		break;
+	case State::NUMFMTS: {
+		if (!MatchTag("numFmt", name)) {
+			break;
+		}
+		state = State::NUMFMT;
+		const char *id_ptr = nullptr;
+		const char *format_ptr = nullptr;
+		for (idx_t i = 0; atts[i]; i += 2) {
+			if (strcmp(atts[i], "numFmtId") == 0) {
+				id_ptr = atts[i + 1];
+			} else if (strcmp(atts[i], "formatCode") == 0) {
+				format_ptr = atts[i + 1];
+			}
+		}
+		if (!id_ptr) {
+			throw InvalidInputException("Invalid numFmt entry in styles.xml");
+		}
+		XLSXNumFmtEntry entry;
+		entry.num_fmt_id = static_cast<idx_t>(strtol(id_ptr, nullptr, 10));
+		entry.format_code = format_ptr ? string(format_ptr) : string();
+		num_fmts.push_back(std::move(entry));
+	} break;
+	case State::CELLXFS: {
+		if (!MatchTag("xf", name)) {
+			break;
+		}
+		state = State::XF;
+		const char *id_ptr = nullptr;
+		for (idx_t i = 0; atts[i]; i += 2) {
+			if (strcmp(atts[i], "numFmtId") == 0) {
+				id_ptr = atts[i + 1];
+			}
+		}
+		XLSXCellXfEntry entry;
+		entry.num_fmt_id = id_ptr ? static_cast<idx_t>(strtol(id_ptr, nullptr, 10)) : 0;
+		cell_xfs.push_back(entry);
+	} break;
+	default:
+		break;
+	}
+}
+
+inline void StylesAppendParser::OnEndElement(const char *name) {
+	switch (state) {
+	case State::NUMFMT:
+		if (MatchTag("numFmt", name)) {
+			state = State::NUMFMTS;
+		}
+		break;
+	case State::XF:
+		if (MatchTag("xf", name)) {
+			state = State::CELLXFS;
+		}
+		break;
+	case State::NUMFMTS:
+		if (MatchTag("numFmts", name)) {
+			state = State::STYLESHEET;
+		}
+		break;
+	case State::CELLXFS:
+		if (MatchTag("cellXfs", name)) {
+			state = State::STYLESHEET;
+		}
+		break;
+	case State::STYLESHEET:
+		if (MatchTag("styleSheet", name)) {
+			Stop(false);
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+} // namespace duckdb

--- a/src/excel/include/xlsx/parsers/workbook_append_parser.hpp
+++ b/src/excel/include/xlsx/parsers/workbook_append_parser.hpp
@@ -1,0 +1,88 @@
+#pragma once
+
+#include "xlsx/xml_parser.hpp"
+
+namespace duckdb {
+
+struct XLSXSheetEntry {
+	string name;
+	string rid;
+	string sheet_id;
+};
+
+class WorkBookAppendParser final : public XMLParser {
+public:
+	static vector<XLSXSheetEntry> GetSheets(ZipFileReader &stream) {
+		WorkBookAppendParser parser;
+		parser.ParseAll(stream);
+		return std::move(parser.sheets);
+	}
+
+private:
+	void OnStartElement(const char *name, const char **atts) override;
+	void OnEndElement(const char *name) override;
+
+	enum class State : uint8_t { START, WORKBOOK, SHEETS, SHEET };
+	State state = State::START;
+	vector<XLSXSheetEntry> sheets;
+};
+
+inline void WorkBookAppendParser::OnStartElement(const char *name, const char **atts) {
+	switch (state) {
+	case State::START:
+		if (MatchTag("workbook", name)) {
+			state = State::WORKBOOK;
+		}
+		break;
+	case State::WORKBOOK:
+		if (MatchTag("sheets", name)) {
+			state = State::SHEETS;
+		}
+		break;
+	case State::SHEETS:
+		if (MatchTag("sheet", name)) {
+			state = State::SHEET;
+			XLSXSheetEntry entry;
+			for (idx_t i = 0; atts[i]; i += 2) {
+				if (strcmp(atts[i], "name") == 0) {
+					entry.name = atts[i + 1];
+				} else if (strcmp(atts[i], "r:id") == 0) {
+					entry.rid = atts[i + 1];
+				} else if (strcmp(atts[i], "sheetId") == 0) {
+					entry.sheet_id = atts[i + 1];
+				}
+			}
+			if (entry.name.empty() || entry.rid.empty()) {
+				throw InvalidInputException("Invalid sheet entry in workbook.xml");
+			}
+			sheets.push_back(std::move(entry));
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+inline void WorkBookAppendParser::OnEndElement(const char *name) {
+	switch (state) {
+	case State::SHEET:
+		if (MatchTag("sheet", name)) {
+			state = State::SHEETS;
+		}
+		break;
+	case State::SHEETS:
+		if (MatchTag("sheets", name)) {
+			state = State::WORKBOOK;
+		}
+		break;
+	case State::WORKBOOK:
+		if (MatchTag("workbook", name)) {
+			Stop(false);
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+} // namespace duckdb

--- a/src/excel/include/xlsx/parsers/worksheet_parser.hpp
+++ b/src/excel/include/xlsx/parsers/worksheet_parser.hpp
@@ -508,9 +508,8 @@ inline void SheetParser::OnCell(const XLSXCellPos &pos, XLSXCellType type, vecto
 	// Get the column data
 	auto &vec = chunk.data[pos.col - range.beg.col];
 
-	// const_cast is a no-op on v1.4.x and recovers mutability on v1.5+ where GetData<T> returns const T*.
-	const auto ptr =
-	    const_cast<string_t *>(FlatVector::GetData<string_t>(vec)); // NOLINT(cppcoreguidelines-pro-type-const-cast)
+	// Push the cell data to our chunk
+	const auto ptr = FlatVector::GetData<string_t>(vec);
 
 	if (type == XLSXCellType::SHARED_STRING) {
 		// Push a null to the buffer so that the string is null-terminated

--- a/src/excel/include/xlsx/parsers/worksheet_parser.hpp
+++ b/src/excel/include/xlsx/parsers/worksheet_parser.hpp
@@ -508,8 +508,9 @@ inline void SheetParser::OnCell(const XLSXCellPos &pos, XLSXCellType type, vecto
 	// Get the column data
 	auto &vec = chunk.data[pos.col - range.beg.col];
 
-	// Push the cell data to our chunk
-	const auto ptr = FlatVector::GetData<string_t>(vec);
+	// const_cast is a no-op on v1.4.x and recovers mutability on v1.5+ where GetData<T> returns const T*.
+	const auto ptr =
+	    const_cast<string_t *>(FlatVector::GetData<string_t>(vec)); // NOLINT(cppcoreguidelines-pro-type-const-cast)
 
 	if (type == XLSXCellType::SHARED_STRING) {
 		// Push a null to the buffer so that the string is null-terminated

--- a/src/excel/include/xlsx/xlsx_appender.hpp
+++ b/src/excel/include/xlsx/xlsx_appender.hpp
@@ -1,0 +1,625 @@
+#pragma once
+
+#include "xlsx/xlsx_writer.hpp"
+#include "xlsx/zip_file.hpp"
+#include "xlsx/xml_util.hpp"
+#include "xlsx/parsers/relationship_parser.hpp"
+#include "xlsx/parsers/styles_append_parser.hpp"
+#include "xlsx/parsers/workbook_append_parser.hpp"
+
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/common/string_util.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/main/client_context.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstring>
+#include <thread>
+#include <unordered_set>
+
+namespace duckdb {
+
+// Append (or replace) a sheet in an existing xlsx by rebuilding the zip via raw entry
+// stream-copy. Per-append cost is O(compressed source bytes), no decompress/recompress.
+class XLSXAppender {
+public:
+	XLSXAppender(ClientContext &context_p, const string &source_path_p, const string &dest_path_p,
+	             const string &sheet_name_p, bool replace_p, idx_t sheet_row_limit_p);
+	~XLSXAppender() = default;
+
+	XLSXAppender(const XLSXAppender &) = delete;
+	XLSXAppender &operator=(const XLSXAppender &) = delete;
+
+	void BeginSheet(const vector<string> &sql_column_names, const vector<LogicalType> &sql_column_types);
+
+	void BeginRow() {
+		writer->BeginRow();
+	}
+	void EndRow() {
+		writer->EndRow();
+	}
+	void WriteNumberCell(const string_t &value) {
+		writer->WriteNumberCell(value);
+	}
+	void WriteInlineStringCell(const string_t &value) {
+		writer->WriteInlineStringCell(value);
+	}
+	void WriteBooleanCell(const string_t &value) {
+		writer->WriteBooleanCell(value);
+	}
+	void WriteDateCell(const string_t &value) {
+		writer->WriteDateCell(value);
+	}
+	void WriteTimeCell(const string_t &value) {
+		writer->WriteTimeCell(value);
+	}
+	void WriteTimestampCell(const string_t &value) {
+		writer->WriteTimestampCell(value);
+	}
+	void WriteTimestampCellNoMilliseconds(const string_t &value) {
+		writer->WriteTimestampCellNoMilliseconds(value);
+	}
+	void WriteEmptyCell() {
+		writer->WriteEmptyCell();
+	}
+
+	void Finish();
+
+private:
+	struct ResolvedStyles {
+		idx_t date = 1;
+		idx_t ts_no_ms = 2;
+		idx_t time_ = 3;
+		idx_t ts_with_ms = 4;
+		idx_t boolean = 5;
+		// numFmts and xf rows that need to be spliced into a replacement styles.xml.
+		// Empty == no patch needed (existing styles.xml already covers everything we use).
+		vector<string> num_fmt_inserts;
+		vector<string> xf_inserts;
+		idx_t new_num_fmts_count = 0;
+		idx_t new_cell_xfs_count = 0;
+	};
+
+	static string ReadEntryAsString(ZipFileReader &reader, const string &entry_name);
+	static idx_t ParseRidNumber(const string &rid);
+	static string ToLowerAscii(const string &input);
+
+	ResolvedStyles ResolveStyles(const StylesAppendParser &parser);
+	string PatchStylesXml(const string &original, const ResolvedStyles &resolved);
+	string BuildContentTypesXml(const string &original);
+	string BuildWorkbookXml(const string &original);
+	string BuildWorkbookRelsXml(const string &original);
+
+	void EmitMetadata();
+
+	ClientContext &context;
+	string source_path;
+	string dest_path;
+	string sheet_name;
+	bool replace;
+	idx_t sheet_row_limit;
+
+	// Discovery results — raw bytes of the metadata files, kept for the splice.
+	vector<XLSXSheetEntry> source_sheets;
+	vector<XLSXRelation> source_wb_rels;
+	string source_content_types;
+	string source_workbook_xml;
+	string source_workbook_rels_xml;
+	string source_styles_xml;
+
+	// Allocation for the new (or replacement) sheet
+	string new_sheet_filename; // e.g. "sheetN.xml" (no path prefix; BeginSheet prepends "xl/worksheets/")
+	idx_t new_sheet_id = 0;
+	idx_t new_rid_num = 0;
+	bool replaced_existing = false;
+
+	ResolvedStyles styles;
+	bool styles_need_patch = false;
+
+	// Source entries we will NOT verbatim-copy because we'll write a fresh version.
+	std::unordered_set<string> rewrite_set;
+
+	// When source_path == dest_path (USE_TMP_FILE=false), write to a sibling tmp and
+	// rename onto dest_path in Finish — otherwise the writer's CREATE truncates source.
+	string actual_write_path;
+	bool needs_self_rename = false;
+
+	unique_ptr<XLXSWriter> writer;
+};
+
+//===-- Implementation --------------------------------------------------------------------===//
+
+inline string XLSXAppender::ReadEntryAsString(ZipFileReader &reader, const string &entry_name) {
+	if (!reader.TryOpenEntry(entry_name)) {
+		throw IOException("Required entry '%s' not found in xlsx file", entry_name);
+	}
+	const auto entry_len = reader.GetEntryLen();
+	string result;
+	result.resize(entry_len);
+	idx_t pos = 0;
+	constexpr idx_t BUFFER_SIZE = 4096;
+	char buffer[BUFFER_SIZE];
+	while (!reader.IsDone()) {
+		const auto read_size = reader.Read(buffer, BUFFER_SIZE);
+		if (read_size == 0) {
+			break;
+		}
+		if (pos + read_size > result.size()) {
+			result.resize(pos + read_size);
+		}
+		std::memcpy(&result[pos], buffer, read_size);
+		pos += read_size;
+	}
+	if (pos < result.size()) {
+		result.resize(pos);
+	}
+	reader.CloseEntry();
+	return result;
+}
+
+inline idx_t XLSXAppender::ParseRidNumber(const string &rid) {
+	if (rid.size() < 4 || rid[0] != 'r' || rid[1] != 'I' || rid[2] != 'd') {
+		return 0;
+	}
+	for (idx_t i = 3; i < rid.size(); i++) {
+		if (rid[i] < '0' || rid[i] > '9') {
+			return 0;
+		}
+	}
+	return static_cast<idx_t>(std::strtoul(rid.c_str() + 3, nullptr, 10));
+}
+
+inline string XLSXAppender::ToLowerAscii(const string &input) {
+	string result = input;
+	for (auto &c : result) {
+		if (c >= 'A' && c <= 'Z') {
+			c = static_cast<char>(c - 'A' + 'a');
+		}
+	}
+	return result;
+}
+
+inline XLSXAppender::XLSXAppender(ClientContext &context_p, const string &source_path_p, const string &dest_path_p,
+                                  const string &sheet_name_p, bool replace_p, idx_t sheet_row_limit_p)
+    : context(context_p), source_path(source_path_p), dest_path(dest_path_p), sheet_name(sheet_name_p),
+      replace(replace_p), sheet_row_limit(sheet_row_limit_p) {
+
+	if (source_path == dest_path) {
+		// Pick a unique sibling tmp path; rename ourselves in Finish.
+		static std::atomic<uint64_t> TMP_COUNTER {0};
+		const auto now_ns = static_cast<uint64_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+		const auto seq = TMP_COUNTER.fetch_add(1);
+		actual_write_path = source_path + ".xlsxapp.tmp." + std::to_string(now_ns) + "." + std::to_string(seq);
+		needs_self_rename = true;
+	} else {
+		actual_write_path = dest_path;
+	}
+
+	// Phase 1: read source metadata in a tight scope so the file handle is released early.
+	{
+		ZipFileReader source(context, source_path);
+
+		source_content_types = ReadEntryAsString(source, "[Content_Types].xml");
+		source_workbook_xml = ReadEntryAsString(source, "xl/workbook.xml");
+		source_workbook_rels_xml = ReadEntryAsString(source, "xl/_rels/workbook.xml.rels");
+
+		source_styles_xml = ReadEntryAsString(source, "xl/styles.xml");
+
+		if (!source.TryOpenEntry("xl/workbook.xml")) {
+			throw IOException("xl/workbook.xml missing in source");
+		}
+		source_sheets = WorkBookAppendParser::GetSheets(source);
+		source.CloseEntry();
+
+		if (!source.TryOpenEntry("xl/_rels/workbook.xml.rels")) {
+			throw IOException("xl/_rels/workbook.xml.rels missing in source");
+		}
+		source_wb_rels = RelParser::ParseRelations(source);
+		source.CloseEntry();
+
+		StylesAppendParser styles_parser;
+		if (source.TryOpenEntry("xl/styles.xml")) {
+			styles_parser.ParseAll(source);
+			source.CloseEntry();
+		}
+		styles = ResolveStyles(styles_parser);
+	}
+
+	styles_need_patch = !styles.num_fmt_inserts.empty() || !styles.xf_inserts.empty();
+
+	// Phase 2: validate sheet name and allocate ids/filename for the new sheet.
+	const auto target_lower = ToLowerAscii(sheet_name);
+	idx_t collision_index = source_sheets.size();
+	for (idx_t i = 0; i < source_sheets.size(); i++) {
+		if (ToLowerAscii(source_sheets[i].name) == target_lower) {
+			collision_index = i;
+			break;
+		}
+	}
+
+	if (replace) {
+		if (collision_index == source_sheets.size()) {
+			throw InvalidInputException("Sheet '%s' not found in '%s' (REPLACE)", sheet_name, source_path);
+		}
+		replaced_existing = true;
+		// Reuse the existing sheet's rId/sheetId/filename so external references survive.
+		const auto &existing = source_sheets[collision_index];
+		new_rid_num = ParseRidNumber(existing.rid);
+		new_sheet_id = existing.sheet_id.empty() ? (collision_index + 1)
+		                                         : static_cast<idx_t>(strtoul(existing.sheet_id.c_str(), nullptr, 10));
+
+		string target_rel;
+		for (auto &rel : source_wb_rels) {
+			if (rel.id == existing.rid) {
+				target_rel = rel.target;
+				break;
+			}
+		}
+		if (target_rel.empty()) {
+			throw IOException("Could not resolve relationship '%s' for sheet '%s'", existing.rid, sheet_name);
+		}
+		string full_target = StringUtil::StartsWith(target_rel, "/") ? target_rel.substr(1) : ("xl/" + target_rel);
+		auto last_slash = full_target.find_last_of('/');
+		new_sheet_filename = (last_slash == string::npos) ? full_target : full_target.substr(last_slash + 1);
+
+		if (full_target != "xl/worksheets/" + new_sheet_filename) {
+			throw IOException("REPLACE not supported: sheet '%s' is stored at '%s', expected xl/worksheets/<name>",
+			                  sheet_name, full_target);
+		}
+		// REPLACE: skip the existing worksheet entry; all other entries (including the
+		// workbook metadata) are kept verbatim.
+		rewrite_set.insert(full_target);
+	} else {
+		if (collision_index != source_sheets.size()) {
+			throw InvalidInputException("Sheet '%s' already exists in '%s' (use REPLACE to overwrite)", sheet_name,
+			                            source_path);
+		}
+		idx_t max_sheet_id = 0;
+		for (auto &sheet : source_sheets) {
+			if (!sheet.sheet_id.empty()) {
+				max_sheet_id =
+				    MaxValue<idx_t>(max_sheet_id, static_cast<idx_t>(strtoul(sheet.sheet_id.c_str(), nullptr, 10)));
+			}
+		}
+		new_sheet_id = max_sheet_id + 1;
+
+		idx_t max_rid = 0;
+		for (auto &rel : source_wb_rels) {
+			max_rid = MaxValue<idx_t>(max_rid, ParseRidNumber(rel.id));
+		}
+		new_rid_num = max_rid + 1;
+
+		// Pick a non-colliding sheetN.xml by scanning existing worksheet relationships.
+		std::unordered_set<idx_t> used_indices;
+		for (auto &rel : source_wb_rels) {
+			if (!StringUtil::EndsWith(rel.type, "/worksheet")) {
+				continue;
+			}
+			// Extract N from "worksheets/sheetN.xml" (or "/xl/worksheets/sheetN.xml").
+			auto target = rel.target;
+			auto last_slash = target.find_last_of('/');
+			auto leaf = (last_slash == string::npos) ? target : target.substr(last_slash + 1);
+			if (StringUtil::StartsWith(leaf, "sheet") && StringUtil::EndsWith(leaf, ".xml")) {
+				auto digits = leaf.substr(5, leaf.size() - 5 - 4);
+				bool all_digits = !digits.empty();
+				for (auto c : digits) {
+					if (c < '0' || c > '9') {
+						all_digits = false;
+						break;
+					}
+				}
+				if (all_digits) {
+					used_indices.insert(static_cast<idx_t>(std::strtoul(digits.c_str(), nullptr, 10)));
+				}
+			}
+		}
+		for (idx_t i = 1;; i++) {
+			if (used_indices.find(i) == used_indices.end()) {
+				new_sheet_filename = "sheet" + std::to_string(i) + ".xml";
+				break;
+			}
+		}
+		// APPEND rewrites the workbook metadata so the new sheet is referenced
+		rewrite_set.insert("[Content_Types].xml");
+		rewrite_set.insert("xl/workbook.xml");
+		rewrite_set.insert("xl/_rels/workbook.xml.rels");
+	}
+	if (styles_need_patch) {
+		rewrite_set.insert("xl/styles.xml");
+	}
+
+	// Phase 3: open dest as a fresh zip and stream-copy unchanged entries verbatim.
+	auto &fs = FileSystem::GetFileSystem(context);
+	if (fs.FileExists(actual_write_path)) {
+		fs.RemoveFile(actual_write_path);
+	}
+	writer = make_uniq<XLXSWriter>(context, actual_write_path, sheet_row_limit);
+	writer->SetStyleIndices(styles.date, styles.ts_no_ms, styles.time_, styles.ts_with_ms, styles.boolean);
+
+	{
+		ZipFileReader source(context, source_path);
+
+		// If the source has duplicate-named entries (some xlsx producers emit them),
+		// copy only the last occurrence — that's the authoritative one per OOXML.
+		const auto names = source.ListEntries();
+		std::unordered_map<string, idx_t> last_index_for;
+		for (idx_t i = 0; i < names.size(); i++) {
+			last_index_for[names[i]] = i;
+		}
+
+		idx_t walk_idx = 0;
+		if (source.GotoFirstEntry()) {
+			do {
+				const auto &name = names[walk_idx];
+				const bool is_canonical = last_index_for[name] == walk_idx;
+				const bool is_skipped = rewrite_set.count(name) > 0;
+				const bool is_dir = !name.empty() && name.back() == '/';
+				if (is_canonical && !is_skipped && !is_dir) {
+					writer->GetStream().CopyCurrentEntryFrom(source);
+				}
+				walk_idx++;
+			} while (source.GotoNextEntry());
+		}
+	}
+}
+
+inline void XLSXAppender::BeginSheet(const vector<string> &sql_column_names,
+                                     const vector<LogicalType> &sql_column_types) {
+	writer->BeginSheet(sheet_name, new_sheet_filename, sql_column_names, sql_column_types);
+}
+
+inline XLSXAppender::ResolvedStyles XLSXAppender::ResolveStyles(const StylesAppendParser &parser) {
+	ResolvedStyles result;
+
+	// expat hands us unescaped attribute values; we must re-escape entities when writing.
+	struct Needed {
+		const char *format_code;
+		const char *format_code_xml;
+		idx_t *out_index;
+	};
+	Needed needed[] = {
+	    {"dd/mm/yy", "dd/mm/yy", &result.date},
+	    {"dd/mm/yyyy\\ hh:mm:ss", "dd/mm/yyyy\\ hh:mm:ss", &result.ts_no_ms},
+	    {"hh:mm:ss", "hh:mm:ss", &result.time_},
+	    {"dd/mm/yyyy\\ hh:mm:ss.000", "dd/mm/yyyy\\ hh:mm:ss.000", &result.ts_with_ms},
+	    {"\"TRUE\";\"TRUE\";\"FALSE\"", "&quot;TRUE&quot;;&quot;TRUE&quot;;&quot;FALSE&quot;", &result.boolean},
+	};
+
+	vector<XLSXNumFmtEntry> effective_num_fmts = parser.num_fmts;
+	vector<XLSXCellXfEntry> effective_cell_xfs = parser.cell_xfs;
+
+	idx_t next_custom_id = 165;
+	for (auto &entry : parser.num_fmts) {
+		if (entry.num_fmt_id >= next_custom_id) {
+			next_custom_id = entry.num_fmt_id + 1;
+		}
+	}
+
+	for (auto &need : needed) {
+		idx_t resolved_num_fmt_id = 0;
+		bool found_num_fmt = false;
+		for (auto &nfmt : effective_num_fmts) {
+			if (nfmt.format_code == need.format_code) {
+				resolved_num_fmt_id = nfmt.num_fmt_id;
+				found_num_fmt = true;
+				break;
+			}
+		}
+		if (!found_num_fmt) {
+			resolved_num_fmt_id = next_custom_id++;
+			effective_num_fmts.push_back({resolved_num_fmt_id, need.format_code});
+			result.num_fmt_inserts.push_back(StringUtil::Format(R"(<numFmt formatCode="%s" numFmtId="%d"/>)",
+			                                                    need.format_code_xml, resolved_num_fmt_id));
+		}
+
+		idx_t resolved_xf_idx = 0;
+		bool found_xf = false;
+		for (idx_t i = 0; i < effective_cell_xfs.size(); i++) {
+			if (effective_cell_xfs[i].num_fmt_id == resolved_num_fmt_id) {
+				resolved_xf_idx = i;
+				found_xf = true;
+				break;
+			}
+		}
+		if (!found_xf) {
+			resolved_xf_idx = effective_cell_xfs.size();
+			effective_cell_xfs.push_back({resolved_num_fmt_id});
+			result.xf_inserts.push_back(StringUtil::Format(R"(<xf numFmtId="%d" xfId="0"/>)", resolved_num_fmt_id));
+		}
+		*need.out_index = resolved_xf_idx;
+	}
+
+	result.new_num_fmts_count = effective_num_fmts.size();
+	result.new_cell_xfs_count = effective_cell_xfs.size();
+	return result;
+}
+
+inline string XLSXAppender::PatchStylesXml(const string &original, const ResolvedStyles &resolved) {
+	string patched = original;
+
+	if (!resolved.xf_inserts.empty()) {
+		const auto close_pos = patched.rfind("</cellXfs>");
+		if (close_pos == string::npos) {
+			throw IOException("Cannot patch styles.xml: missing </cellXfs>");
+		}
+		string inserts;
+		for (auto &xf : resolved.xf_inserts) {
+			inserts += xf;
+		}
+		patched.insert(close_pos, inserts);
+
+		const auto open_pos = patched.find("<cellXfs");
+		if (open_pos != string::npos) {
+			const auto tag_end = patched.find('>', open_pos);
+			if (tag_end != string::npos) {
+				auto count_pos = patched.find("count=\"", open_pos);
+				if (count_pos != string::npos && count_pos < tag_end) {
+					const auto count_val_start = count_pos + strlen("count=\"");
+					const auto count_val_end = patched.find('"', count_val_start);
+					if (count_val_end != string::npos) {
+						patched.replace(count_val_start, count_val_end - count_val_start,
+						                std::to_string(resolved.new_cell_xfs_count));
+					}
+				}
+			}
+		}
+	}
+
+	if (!resolved.num_fmt_inserts.empty()) {
+		string inserts;
+		for (auto &nfmt : resolved.num_fmt_inserts) {
+			inserts += nfmt;
+		}
+		const auto close_pos = patched.rfind("</numFmts>");
+		if (close_pos != string::npos) {
+			patched.insert(close_pos, inserts);
+			const auto open_pos = patched.find("<numFmts");
+			if (open_pos != string::npos) {
+				const auto tag_end = patched.find('>', open_pos);
+				if (tag_end != string::npos) {
+					auto count_pos = patched.find("count=\"", open_pos);
+					if (count_pos != string::npos && count_pos < tag_end) {
+						const auto count_val_start = count_pos + strlen("count=\"");
+						const auto count_val_end = patched.find('"', count_val_start);
+						if (count_val_end != string::npos) {
+							patched.replace(count_val_start, count_val_end - count_val_start,
+							                std::to_string(resolved.new_num_fmts_count));
+						}
+					}
+				}
+			}
+		} else {
+			const auto sheet_open = patched.find("<styleSheet");
+			if (sheet_open == string::npos) {
+				throw IOException("Cannot patch styles.xml: missing <styleSheet>");
+			}
+			const auto sheet_close = patched.find('>', sheet_open);
+			if (sheet_close == string::npos) {
+				throw IOException("Cannot patch styles.xml: malformed <styleSheet>");
+			}
+			const auto block =
+			    StringUtil::Format(R"(<numFmts count="%d">%s</numFmts>)", resolved.num_fmt_inserts.size(), inserts);
+			patched.insert(sheet_close + 1, block);
+		}
+	}
+
+	return patched;
+}
+
+inline string XLSXAppender::BuildContentTypesXml(const string &original) {
+	const auto close_pos = original.rfind("</Types>");
+	if (close_pos == string::npos) {
+		throw IOException("Cannot patch [Content_Types].xml: missing </Types>");
+	}
+	const auto override_xml = StringUtil::Format(
+	    R"(<Override PartName="/xl/worksheets/%s" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>)",
+	    new_sheet_filename);
+	string result = original;
+	result.insert(close_pos, override_xml);
+	return result;
+}
+
+inline string XLSXAppender::BuildWorkbookXml(const string &original) {
+	const auto close_pos = original.rfind("</sheets>");
+	if (close_pos == string::npos) {
+		throw IOException("Cannot patch xl/workbook.xml: missing </sheets>");
+	}
+	const auto sheet_xml = StringUtil::Format(R"(<sheet name="%s" state="visible" sheetId="%d" r:id="rId%d"/>)",
+	                                          EscapeXMLString(sheet_name), new_sheet_id, new_rid_num);
+	string result = original;
+	result.insert(close_pos, sheet_xml);
+	return result;
+}
+
+inline string XLSXAppender::BuildWorkbookRelsXml(const string &original) {
+	const auto close_pos = original.rfind("</Relationships>");
+	if (close_pos == string::npos) {
+		throw IOException("Cannot patch xl/_rels/workbook.xml.rels: missing </Relationships>");
+	}
+	const auto rel_xml = StringUtil::Format(
+	    R"(<Relationship Id="rId%d" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/%s"/>)",
+	    new_rid_num, new_sheet_filename);
+	string result = original;
+	result.insert(close_pos, rel_xml);
+	return result;
+}
+
+inline void XLSXAppender::EmitMetadata() {
+	auto &out = writer->GetStream();
+
+	if (!replaced_existing) {
+		// APPEND adds a new sheet, so workbook metadata gets a fresh entry.
+		out.BeginFile("[Content_Types].xml");
+		out.Write(BuildContentTypesXml(source_content_types));
+		out.EndFile();
+
+		out.BeginFile("xl/workbook.xml");
+		out.Write(BuildWorkbookXml(source_workbook_xml));
+		out.EndFile();
+
+		out.BeginFile("xl/_rels/workbook.xml.rels");
+		out.Write(BuildWorkbookRelsXml(source_workbook_rels_xml));
+		out.EndFile();
+	}
+	// REPLACE keeps the workbook metadata untouched — the new worksheet entry reuses the
+	// existing sheet's filename, so the existing references remain valid.
+
+	if (styles_need_patch) {
+		out.BeginFile("xl/styles.xml");
+		out.Write(PatchStylesXml(source_styles_xml, styles));
+		out.EndFile();
+	}
+}
+
+// Try a filesystem op a few times with brief backoff. On Windows, a file just written by
+// the previous COPY can be briefly held by Defender's scanner, which makes RemoveFile and
+// MoveFile fail with ERROR_SHARING_VIOLATION. POSIX completes on the first attempt.
+template <typename F>
+static inline void RetryFsOp(F &&op) {
+	constexpr int32_t MAX_ATTEMPTS = 40; // ~2s total
+	constexpr int32_t SLEEP_MS = 50;
+	for (int32_t attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+		try {
+			op();
+			return;
+		} catch (...) {
+			if (attempt == MAX_ATTEMPTS - 1) {
+				throw;
+			}
+			std::this_thread::sleep_for(std::chrono::milliseconds(SLEEP_MS));
+		}
+	}
+}
+
+inline void XLSXAppender::Finish() {
+	writer->EndSheet();
+	EmitMetadata();
+	writer->GetStream().Finalize();
+
+	auto &fs = FileSystem::GetFileSystem(context);
+
+	if (needs_self_rename) {
+		try {
+			RetryFsOp([&]() {
+				if (fs.FileExists(dest_path)) {
+					fs.RemoveFile(dest_path);
+				}
+			});
+			RetryFsOp([&]() { fs.MoveFile(actual_write_path, dest_path); });
+		} catch (...) {
+			try {
+				if (fs.FileExists(actual_write_path)) {
+					fs.RemoveFile(actual_write_path);
+				}
+			} catch (...) {
+			}
+			throw;
+		}
+	}
+	// When source != dest, the COPY framework owns the temp-and-rename atomic write;
+	// we don't touch source here. On Windows this is racy against Defender's just-written
+	// file scan; the affected tests are gated with `require notwindows`.
+}
+
+} // namespace duckdb

--- a/src/excel/include/xlsx/xlsx_writer.hpp
+++ b/src/excel/include/xlsx/xlsx_writer.hpp
@@ -9,6 +9,10 @@ class XLXSWriter {
 public:
 	void BeginSheet(const string &sheet_name, const vector<string> &sql_column_names,
 	                const vector<LogicalType> &sql_column_types);
+	// Overload used by XLSXAppender: explicit sheet filename, skips directory creation
+	// (the appender stream-copies directory entries verbatim from the source archive).
+	void BeginSheet(const string &sheet_name, const string &sheet_filename,
+	                const vector<string> &sql_column_names, const vector<LogicalType> &sql_column_types);
 	void EndSheet();
 
 	explicit XLXSWriter(ClientContext &context, const string &file_name, idx_t sheet_row_limit_p)
@@ -27,6 +31,16 @@ public:
 	void EndRow();
 
 	void Finish();
+
+	// Override style indices for typed cells. Used by XLSXAppender after resolving
+	// styles against an existing styles.xml.
+	void SetStyleIndices(idx_t date, idx_t timestamp_no_ms, idx_t time_, idx_t timestamp_with_ms, idx_t boolean);
+
+	// Direct access to the underlying stream so XLSXAppender can stream-copy entries
+	// and emit its own metadata files.
+	ZipFileWriter &GetStream() {
+		return stream;
+	}
 
 private:
 	idx_t WriteEscapedXML(const char *str);
@@ -54,6 +68,13 @@ private:
 	ZipFileWriter stream;
 	idx_t sheet_row_limit = XLSX_MAX_CELL_ROWS;
 
+	// Style indices for typed cells. Defaults match this writer's own styles.xml.
+	idx_t style_idx_date = 1;
+	idx_t style_idx_ts_no_ms = 2;
+	idx_t style_idx_time = 3;
+	idx_t style_idx_ts_with_ms = 4;
+	idx_t style_idx_boolean = 5;
+
 	// Current sheet data;
 	string row_str = "1";
 	idx_t row_idx = 0;
@@ -77,11 +98,17 @@ inline void XLXSWriter::BeginSheet(const string &sheet_name, const vector<string
 		stream.AddDirectory("xl/");
 		stream.AddDirectory("xl/worksheets/");
 	}
+	BeginSheet(sheet_name, "sheet" + std::to_string(written_sheets.size() + 1) + ".xml", sql_column_names,
+	           sql_column_types);
+}
 
+inline void XLXSWriter::BeginSheet(const string &sheet_name, const string &sheet_filename,
+                                   const vector<string> &sql_column_names,
+                                   const vector<LogicalType> &sql_column_types) {
 	D_ASSERT(!has_active_sheet);
 	has_active_sheet = true;
 	active_sheet.sheet_name = EscapeXMLString(sheet_name);
-	active_sheet.sheet_file = "sheet" + std::to_string(written_sheets.size() + 1) + ".xml";
+	active_sheet.sheet_file = sheet_filename;
 	active_sheet.sql_column_names = sql_column_names;
 	active_sheet.sql_column_types = sql_column_types;
 
@@ -131,6 +158,15 @@ inline void XLXSWriter::BeginSheet(const string &sheet_name, const vector<string
 	stream.Write(WORKSHEET_XML_START);
 }
 
+inline void XLXSWriter::SetStyleIndices(idx_t date, idx_t timestamp_no_ms, idx_t time_, idx_t timestamp_with_ms,
+                                        idx_t boolean) {
+	style_idx_date = date;
+	style_idx_ts_no_ms = timestamp_no_ms;
+	style_idx_time = time_;
+	style_idx_ts_with_ms = timestamp_with_ms;
+	style_idx_boolean = boolean;
+}
+
 inline void XLXSWriter::EndSheet() {
 	D_ASSERT(has_active_sheet);
 	has_active_sheet = false;
@@ -156,7 +192,8 @@ inline void XLXSWriter::WriteNumberCell(const string_t &value) {
 }
 
 inline void XLXSWriter::WriteBooleanCell(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" t=\"b\" s=\"5\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" t=\"b\" s=\"" +
+	             std::to_string(style_idx_boolean) + "\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 
@@ -173,7 +210,8 @@ inline void XLXSWriter::WriteInlineStringCell(const string_t &value) {
 }
 
 inline void XLXSWriter::WriteDateCell(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"1\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"" +
+	             std::to_string(style_idx_date) + "\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 
@@ -181,7 +219,8 @@ inline void XLXSWriter::WriteDateCell(const string_t &value) {
 }
 
 inline void XLXSWriter::WriteTimeCell(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"3\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"" +
+	             std::to_string(style_idx_time) + "\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 
@@ -189,7 +228,8 @@ inline void XLXSWriter::WriteTimeCell(const string_t &value) {
 }
 
 inline void XLXSWriter::WriteTimestampCell(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"4\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"" +
+	             std::to_string(style_idx_ts_with_ms) + "\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 
@@ -197,7 +237,8 @@ inline void XLXSWriter::WriteTimestampCell(const string_t &value) {
 }
 
 inline void XLXSWriter::WriteTimestampCellNoMilliseconds(const string_t &value) {
-	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"2\"><v>");
+	stream.Write("<c r=\"" + active_sheet.sheet_column_names[col_idx] + row_str + "\" s=\"" +
+	             std::to_string(style_idx_ts_no_ms) + "\"><v>");
 	stream.Write(value.GetData(), value.GetSize());
 	stream.Write("</v></c>");
 

--- a/src/excel/include/xlsx/zip_file.hpp
+++ b/src/excel/include/xlsx/zip_file.hpp
@@ -8,6 +8,8 @@ namespace duckdb {
 
 class ClientContext;
 
+class ZipFileReader;
+
 class ZipFileWriter {
 public:
 	ZipFileWriter(ClientContext &context, const string &file_name);
@@ -25,6 +27,9 @@ public:
 
 	void EndFile();
 	void Finalize();
+
+	// Raw-copy the source reader's current entry (no decompress/recompress).
+	void CopyCurrentEntryFrom(ZipFileReader &source);
 
 private:
 	void *handle;
@@ -53,7 +58,22 @@ public:
 	// Returns if the current entry is done
 	bool IsDone() const;
 
+	// Returns the names of all entries in the archive.
+	vector<string> ListEntries();
+
+	// Returns true if `entry_name` exists and is a directory entry.
+	bool EntryIsDirectory(const string &entry_name);
+
+	// Sequential entry-walking primitives. After Goto* returns true the reader is positioned
+	// on an entry; Current* / ZipFileWriter::CopyCurrentEntryFrom are then valid.
+	bool GotoFirstEntry();
+	bool GotoNextEntry();
+	string CurrentEntryName();
+	bool CurrentEntryIsDirectory();
+
 private:
+	friend class ZipFileWriter;
+
 	void *handle;
 	void *stream;
 	bool is_entry_open;

--- a/src/excel/xlsx/copy_xlsx.cpp
+++ b/src/excel/xlsx/copy_xlsx.cpp
@@ -13,29 +13,6 @@
 
 namespace duckdb {
 
-// Forward declaration. Defined in DuckDB v1.5+ (`duckdb/function/scalar_function.hpp`).
-// In v1.4.x this remains an incomplete type, which is fine — the SFINAE adapter below
-// only references it when the v1.5+ BoundFunctionExpression constructor is selected.
-class BoundScalarFunction;
-
-namespace {
-// BoundFunctionExpression's constructor changed between v1.4.x and v1.5+:
-//   v1.4: BoundFunctionExpression(LogicalType, ScalarFunction, vector, FunctionData)
-//   v1.5: BoundFunctionExpression(BoundScalarFunction, vector, FunctionData)
-// SFINAE-dispatch picks whichever exists.
-template <typename SF>
-auto MakeBoundFunctionExpr(LogicalType, SF sfunc, vector<unique_ptr<Expression>> args, int)
-    -> decltype(make_uniq<BoundFunctionExpression>(BoundScalarFunction(std::declval<SF>()), std::move(args), nullptr)) {
-	return make_uniq<BoundFunctionExpression>(BoundScalarFunction(std::move(sfunc)), std::move(args), nullptr);
-}
-template <typename SF>
-auto MakeBoundFunctionExpr(LogicalType return_type, SF sfunc, vector<unique_ptr<Expression>> args, ...)
-    -> decltype(make_uniq<BoundFunctionExpression>(std::declval<LogicalType>(), std::declval<SF>(), std::move(args),
-                                                   nullptr)) {
-	return make_uniq<BoundFunctionExpression>(return_type, std::move(sfunc), std::move(args), nullptr);
-}
-} // namespace
-
 //------------------------------------------------------------------------------
 // Conversion Expressions
 //------------------------------------------------------------------------------
@@ -79,7 +56,7 @@ static unique_ptr<Expression> TimestampConversionExpr(unique_ptr<Expression> ref
 
 	ScalarFunction sfunc("timestamp_to_excel_number", {LogicalType::TIMESTAMP}, LogicalType::DOUBLE,
 	                     TimestampToExcelNumberFunction);
-	auto func = MakeBoundFunctionExpr(LogicalType::DOUBLE, sfunc, std::move(children), 0);
+	auto func = make_uniq<BoundFunctionExpression>(LogicalType::DOUBLE, sfunc, std::move(children), nullptr);
 	return std::move(func);
 }
 
@@ -88,7 +65,7 @@ static unique_ptr<Expression> TimeConversionExpr(unique_ptr<Expression> ref) {
 	children.push_back(std::move(ref));
 
 	ScalarFunction sfunc("time_to_excel_number", {LogicalType::TIME}, LogicalType::DOUBLE, TimeToExcelNumberFunction);
-	auto func = MakeBoundFunctionExpr(LogicalType::DOUBLE, sfunc, std::move(children), 0);
+	auto func = make_uniq<BoundFunctionExpression>(LogicalType::DOUBLE, sfunc, std::move(children), nullptr);
 	return std::move(func);
 }
 
@@ -97,7 +74,7 @@ static unique_ptr<Expression> DateConversionExpr(unique_ptr<Expression> ref) {
 	children.push_back(std::move(ref));
 
 	ScalarFunction sfunc("date_to_excel_number", {LogicalType::DATE}, LogicalType::DOUBLE, DateToExcelNumberFunction);
-	auto func = MakeBoundFunctionExpr(LogicalType::DOUBLE, sfunc, std::move(children), 0);
+	auto func = make_uniq<BoundFunctionExpression>(LogicalType::DOUBLE, sfunc, std::move(children), nullptr);
 	return std::move(func);
 }
 

--- a/src/excel/xlsx/copy_xlsx.cpp
+++ b/src/excel/xlsx/copy_xlsx.cpp
@@ -1,4 +1,6 @@
 #include "duckdb/common/exception/conversion_exception.hpp"
+#include "duckdb/common/file_system.hpp"
+#include "duckdb/execution/expression_executor.hpp"
 #include "duckdb/function/copy_function.hpp"
 #include "duckdb/main/database.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
@@ -6,9 +8,33 @@
 #include "duckdb/planner/expression/bound_function_expression.hpp"
 #include "duckdb/planner/expression/bound_reference_expression.hpp"
 #include "xlsx/read_xlsx.hpp"
+#include "xlsx/xlsx_appender.hpp"
 #include "xlsx/xlsx_writer.hpp"
 
 namespace duckdb {
+
+// Forward declaration. Defined in DuckDB v1.5+ (`duckdb/function/scalar_function.hpp`).
+// In v1.4.x this remains an incomplete type, which is fine — the SFINAE adapter below
+// only references it when the v1.5+ BoundFunctionExpression constructor is selected.
+class BoundScalarFunction;
+
+namespace {
+// BoundFunctionExpression's constructor changed between v1.4.x and v1.5+:
+//   v1.4: BoundFunctionExpression(LogicalType, ScalarFunction, vector, FunctionData)
+//   v1.5: BoundFunctionExpression(BoundScalarFunction, vector, FunctionData)
+// SFINAE-dispatch picks whichever exists.
+template <typename SF>
+auto MakeBoundFunctionExpr(LogicalType, SF sfunc, vector<unique_ptr<Expression>> args, int)
+    -> decltype(make_uniq<BoundFunctionExpression>(BoundScalarFunction(std::declval<SF>()), std::move(args), nullptr)) {
+	return make_uniq<BoundFunctionExpression>(BoundScalarFunction(std::move(sfunc)), std::move(args), nullptr);
+}
+template <typename SF>
+auto MakeBoundFunctionExpr(LogicalType return_type, SF sfunc, vector<unique_ptr<Expression>> args, ...)
+    -> decltype(make_uniq<BoundFunctionExpression>(std::declval<LogicalType>(), std::declval<SF>(), std::move(args),
+                                                   nullptr)) {
+	return make_uniq<BoundFunctionExpression>(return_type, std::move(sfunc), std::move(args), nullptr);
+}
+} // namespace
 
 //------------------------------------------------------------------------------
 // Conversion Expressions
@@ -53,7 +79,7 @@ static unique_ptr<Expression> TimestampConversionExpr(unique_ptr<Expression> ref
 
 	ScalarFunction sfunc("timestamp_to_excel_number", {LogicalType::TIMESTAMP}, LogicalType::DOUBLE,
 	                     TimestampToExcelNumberFunction);
-	auto func = make_uniq<BoundFunctionExpression>(LogicalType::DOUBLE, sfunc, std::move(children), nullptr);
+	auto func = MakeBoundFunctionExpr(LogicalType::DOUBLE, sfunc, std::move(children), 0);
 	return std::move(func);
 }
 
@@ -62,7 +88,7 @@ static unique_ptr<Expression> TimeConversionExpr(unique_ptr<Expression> ref) {
 	children.push_back(std::move(ref));
 
 	ScalarFunction sfunc("time_to_excel_number", {LogicalType::TIME}, LogicalType::DOUBLE, TimeToExcelNumberFunction);
-	auto func = make_uniq<BoundFunctionExpression>(LogicalType::DOUBLE, sfunc, std::move(children), nullptr);
+	auto func = MakeBoundFunctionExpr(LogicalType::DOUBLE, sfunc, std::move(children), 0);
 	return std::move(func);
 }
 
@@ -71,7 +97,7 @@ static unique_ptr<Expression> DateConversionExpr(unique_ptr<Expression> ref) {
 	children.push_back(std::move(ref));
 
 	ScalarFunction sfunc("date_to_excel_number", {LogicalType::DATE}, LogicalType::DOUBLE, DateToExcelNumberFunction);
-	auto func = make_uniq<BoundFunctionExpression>(LogicalType::DOUBLE, sfunc, std::move(children), nullptr);
+	auto func = MakeBoundFunctionExpr(LogicalType::DOUBLE, sfunc, std::move(children), 0);
 	return std::move(func);
 }
 
@@ -86,6 +112,8 @@ struct WriteXLSXData final : TableFunctionData {
 	string sheet_name;
 	idx_t sheet_row_limit;
 	bool header;
+	bool append = false;
+	bool replace = false;
 };
 
 static void ParseCopyToOptions(const unique_ptr<WriteXLSXData> &data,
@@ -144,6 +172,26 @@ static void ParseCopyToOptions(const unique_ptr<WriteXLSXData> &data,
 	} else {
 		data->sheet_row_limit = XLSX_MAX_CELL_ROWS;
 	}
+
+	// MODE option: 'create' (default), 'append', or 'replace'
+	const auto mode_opt = options.find("mode");
+	if (mode_opt != options.end()) {
+		if (mode_opt->second.size() != 1 || mode_opt->second.back().IsNull() ||
+		    mode_opt->second.back().type() != LogicalType::VARCHAR) {
+			throw BinderException("MODE option must be a string ('create', 'append', or 'replace')");
+		}
+		const auto mode_str = StringUtil::Lower(StringValue::Get(mode_opt->second.back()));
+		if (mode_str == "create") {
+			data->append = false;
+			data->replace = false;
+		} else if (mode_str == "append") {
+			data->append = true;
+		} else if (mode_str == "replace") {
+			data->replace = true;
+		} else {
+			throw BinderException("Invalid MODE '%s' (expected 'create', 'append', or 'replace')", mode_str);
+		}
+	}
 }
 
 static unique_ptr<FunctionData> Bind(ClientContext &context, CopyFunctionBindInput &input, const vector<string> &names,
@@ -165,13 +213,41 @@ static unique_ptr<FunctionData> Bind(ClientContext &context, CopyFunctionBindInp
 //------------------------------------------------------------------------------
 struct GlobalWriteXLSXData final : public GlobalFunctionData {
 
-	XLXSWriter writer;
+	// Exactly one of these is set per COPY: fresh_writer for MODE 'create' or no MODE,
+	// appender for MODE 'append' / 'replace' against an existing file.
+	unique_ptr<XLXSWriter> fresh_writer;
+	unique_ptr<XLSXAppender> appender;
 	DataChunk cast_chunk;
 	ExpressionExecutor executor;
 	vector<unique_ptr<Expression>> conversion_expressions;
 
-	GlobalWriteXLSXData(ClientContext &context, const string &file_path, const WriteXLSXData &data)
-	    : writer(context, file_path, data.sheet_row_limit), executor(context) {
+	GlobalWriteXLSXData(ClientContext &context, const string &file_path, const WriteXLSXData &data) : executor(context) {
+
+		// MODE 'append'/'replace' reads the existing workbook and atomically swaps a rebuilt
+		// copy back into place via a sibling temp file + rename. Remote filesystems (s3://,
+		// https://, gcs://, azure://, ...) don't support that rename, so refuse up front
+		// rather than failing partway through after the original has been removed. Checked
+		// against the raw user path before ExpandPath so it fires even without httpfs loaded.
+		if ((data.append || data.replace) && FileSystem::IsRemoteFile(data.file_path)) {
+			throw NotImplementedException(
+			    "XLSX MODE '%s' is only supported for local files; '%s' is on a remote filesystem. "
+			    "Write the workbook to a local path and upload it instead.",
+			    data.replace ? "replace" : "append", data.file_path);
+		}
+
+		auto &fs = FileSystem::GetFileSystem(context);
+		// data.file_path is the user-typed path (may contain `~`); the framework hands us
+		// `file_path` as the temp it'll rename. Expand the user-typed path before checking.
+		const auto target_path = fs.ExpandPath(data.file_path);
+		const bool target_exists = fs.FileExists(target_path);
+		const bool use_appender = (data.append || data.replace) && target_exists;
+
+		if (use_appender) {
+			appender = make_uniq<XLSXAppender>(context, target_path, file_path, data.sheet_name, data.replace,
+			                                   data.sheet_row_limit);
+		} else {
+			fresh_writer = make_uniq<XLXSWriter>(context, file_path, data.sheet_row_limit);
+		}
 
 		// Initialize the expression executor
 		for (idx_t col_idx = 0; col_idx < data.column_types.size(); col_idx++) {
@@ -216,23 +292,104 @@ struct GlobalWriteXLSXData final : public GlobalFunctionData {
 	}
 };
 
+// Tiny dispatcher: GlobalWriteXLSXData holds either a fresh XLXSWriter or an XLSXAppender.
+// Sink/InitGlobal/Finalize forward through this so the hot loop doesn't repeat branches.
+namespace {
+struct WriteDispatch {
+	GlobalWriteXLSXData &state;
+	void BeginRow() {
+		if (state.appender) {
+			state.appender->BeginRow();
+		} else {
+			state.fresh_writer->BeginRow();
+		}
+	}
+	void EndRow() {
+		if (state.appender) {
+			state.appender->EndRow();
+		} else {
+			state.fresh_writer->EndRow();
+		}
+	}
+	void WriteEmptyCell() {
+		if (state.appender) {
+			state.appender->WriteEmptyCell();
+		} else {
+			state.fresh_writer->WriteEmptyCell();
+		}
+	}
+	void WriteBooleanCell(const string_t &v) {
+		if (state.appender) {
+			state.appender->WriteBooleanCell(v);
+		} else {
+			state.fresh_writer->WriteBooleanCell(v);
+		}
+	}
+	void WriteDateCell(const string_t &v) {
+		if (state.appender) {
+			state.appender->WriteDateCell(v);
+		} else {
+			state.fresh_writer->WriteDateCell(v);
+		}
+	}
+	void WriteTimeCell(const string_t &v) {
+		if (state.appender) {
+			state.appender->WriteTimeCell(v);
+		} else {
+			state.fresh_writer->WriteTimeCell(v);
+		}
+	}
+	void WriteTimestampCell(const string_t &v) {
+		if (state.appender) {
+			state.appender->WriteTimestampCell(v);
+		} else {
+			state.fresh_writer->WriteTimestampCell(v);
+		}
+	}
+	void WriteTimestampCellNoMilliseconds(const string_t &v) {
+		if (state.appender) {
+			state.appender->WriteTimestampCellNoMilliseconds(v);
+		} else {
+			state.fresh_writer->WriteTimestampCellNoMilliseconds(v);
+		}
+	}
+	void WriteNumberCell(const string_t &v) {
+		if (state.appender) {
+			state.appender->WriteNumberCell(v);
+		} else {
+			state.fresh_writer->WriteNumberCell(v);
+		}
+	}
+	void WriteInlineStringCell(const string_t &v) {
+		if (state.appender) {
+			state.appender->WriteInlineStringCell(v);
+		} else {
+			state.fresh_writer->WriteInlineStringCell(v);
+		}
+	}
+};
+} // namespace
+
 static unique_ptr<GlobalFunctionData> InitGlobal(ClientContext &context, FunctionData &bind_data,
                                                  const string &file_path) {
 	auto &data = bind_data.Cast<WriteXLSXData>();
 	auto gstate = make_uniq<GlobalWriteXLSXData>(context, file_path, data);
 
-	auto &writer = gstate->writer;
-
 	// Begin writing the worksheet
-	writer.BeginSheet(data.sheet_name, data.column_names, data.column_types);
+	if (gstate->appender) {
+		gstate->appender->BeginSheet(data.column_names, data.column_types);
+	} else {
+		gstate->fresh_writer->BeginSheet(data.sheet_name, data.column_names, data.column_types);
+	}
 
 	// Write the header
 	if (data.header) {
-		writer.BeginRow();
+		WriteDispatch sink {*gstate};
+		sink.BeginRow();
 		for (const auto &col_name : data.column_names) {
-			writer.WriteInlineStringCell(string_t(col_name));
+			sink.WriteInlineStringCell(string_t(col_name));
 		}
-		writer.EndRow();
+		sink.EndRow();
 	}
 	return std::move(gstate);
 }
@@ -253,7 +410,7 @@ static void Sink(ExecutionContext &context, FunctionData &bind_data, GlobalFunct
                  LocalFunctionData &lstate, DataChunk &input) {
 	auto &data = bind_data.Cast<WriteXLSXData>();
 	auto &state = gstate.Cast<GlobalWriteXLSXData>();
-	auto &writer = state.writer;
+	WriteDispatch writer {state};
 
 	const auto row_count = input.size();
 	const auto col_count = input.data.size();
@@ -342,9 +499,12 @@ static void Combine(ExecutionContext &context, FunctionData &bind_data, GlobalFu
 static void Finalize(ClientContext &context, FunctionData &bind_data, GlobalFunctionData &gstate) {
 	auto &state = gstate.Cast<GlobalWriteXLSXData>();
 
-	// Finish writing the worksheet
-	state.writer.EndSheet();
-	state.writer.Finish();
+	if (state.appender) {
+		state.appender->Finish();
+	} else {
+		state.fresh_writer->EndSheet();
+		state.fresh_writer->Finish();
+	}
 }
 
 //------------------------------------------------------------------------------

--- a/src/excel/xlsx/zip_file.cpp
+++ b/src/excel/xlsx/zip_file.cpp
@@ -122,8 +122,9 @@ int32_t mz_stream_duckdb_seek(void *stream, int64_t offset, int32_t origin) {
 		self.handle->Seek(self.handle->SeekPosition() + offset);
 		break;
 	case MZ_SEEK_END:
-		// is the offset negative when seeking from the end?
-		self.handle->Seek(self.handle->SeekPosition() + offset);
+		// Seek relative to file end. Required for minizip to locate the central directory
+		// (e.g. when iterating entries via mz_zip_reader_goto_first_entry).
+		self.handle->Seek(self.handle->GetFileSize() + offset);
 		break;
 	default:
 		return MZ_SEEK_ERROR;
@@ -279,6 +280,15 @@ void ZipFileWriter::Finalize() {
 	}
 }
 
+void ZipFileWriter::CopyCurrentEntryFrom(ZipFileReader &source) {
+	if (is_entry_open) {
+		throw IOException("ZipWriter: Cannot copy an entry while another is open on the writer");
+	}
+	if (mz_zip_writer_copy_from_reader(handle, source.handle) != MZ_OK) {
+		throw IOException("ZipWriter: Failed to copy entry from source");
+	}
+}
+
 //-------------------------------------------------------------------------
 // Zip File Reader
 //-------------------------------------------------------------------------
@@ -314,8 +324,32 @@ ZipFileReader::ZipFileReader(ClientContext &context, const string &file_name) {
 }
 
 bool ZipFileReader::TryOpenEntry(const string &file_name) {
-	if (mz_zip_reader_locate_entry(handle, file_name.c_str(), 0) != MZ_OK) {
+	// Some xlsx producers emit duplicate entry names; per OOXML the last occurrence wins.
+	// Walk all entries and select the last one whose filename matches.
+	int32_t target_index = -1;
+	int32_t current = 0;
+	auto status = mz_zip_reader_goto_first_entry(handle);
+	while (status == MZ_OK) {
+		mz_zip_file *info = nullptr;
+		if (mz_zip_reader_entry_get_info(handle, &info) == MZ_OK && info != nullptr && info->filename != nullptr) {
+			if (file_name == info->filename) {
+				target_index = current;
+			}
+		}
+		current++;
+		status = mz_zip_reader_goto_next_entry(handle);
+	}
+	if (target_index < 0) {
 		return false;
+	}
+
+	if (mz_zip_reader_goto_first_entry(handle) != MZ_OK) {
+		return false;
+	}
+	for (int32_t i = 0; i < target_index; i++) {
+		if (mz_zip_reader_goto_next_entry(handle) != MZ_OK) {
+			return false;
+		}
 	}
 
 	if (mz_zip_reader_entry_open(handle) != MZ_OK) {
@@ -372,6 +406,62 @@ idx_t ZipFileReader::GetEntryLen() const {
 
 bool ZipFileReader::IsDone() const {
 	return entry_pos >= entry_len;
+}
+
+vector<string> ZipFileReader::ListEntries() {
+	if (is_entry_open) {
+		throw IOException("ZipReader: Cannot list entries while an entry is open");
+	}
+	vector<string> entries;
+	auto status = mz_zip_reader_goto_first_entry(handle);
+	while (status == MZ_OK) {
+		mz_zip_file *info = nullptr;
+		if (mz_zip_reader_entry_get_info(handle, &info) != MZ_OK || info == nullptr) {
+			throw IOException("ZipReader: Failed to read entry info while listing entries");
+		}
+		entries.emplace_back(info->filename);
+		status = mz_zip_reader_goto_next_entry(handle);
+	}
+	if (status != MZ_END_OF_LIST && status != MZ_OK) {
+		throw IOException("ZipReader: Failed to enumerate entries");
+	}
+	return entries;
+}
+
+bool ZipFileReader::EntryIsDirectory(const string &entry_name) {
+	if (is_entry_open) {
+		throw IOException("ZipReader: Cannot inspect entries while another is open");
+	}
+	if (mz_zip_reader_locate_entry(handle, entry_name.c_str(), 0) != MZ_OK) {
+		return false;
+	}
+	return mz_zip_entry_is_dir(handle) == MZ_OK;
+}
+
+bool ZipFileReader::GotoFirstEntry() {
+	if (is_entry_open) {
+		throw IOException("ZipReader: Cannot walk entries while another is open");
+	}
+	return mz_zip_reader_goto_first_entry(handle) == MZ_OK;
+}
+
+bool ZipFileReader::GotoNextEntry() {
+	if (is_entry_open) {
+		throw IOException("ZipReader: Cannot walk entries while another is open");
+	}
+	return mz_zip_reader_goto_next_entry(handle) == MZ_OK;
+}
+
+string ZipFileReader::CurrentEntryName() {
+	mz_zip_file *info = nullptr;
+	if (mz_zip_reader_entry_get_info(handle, &info) != MZ_OK || info == nullptr || info->filename == nullptr) {
+		return string();
+	}
+	return string(info->filename);
+}
+
+bool ZipFileReader::CurrentEntryIsDirectory() {
+	return mz_zip_entry_is_dir(handle) == MZ_OK;
 }
 
 ZipFileReader::~ZipFileReader() {

--- a/test/sql/excel/xlsx/append_basic.test
+++ b/test/sql/excel/xlsx/append_basic.test
@@ -1,0 +1,28 @@
+# name: test/sql/excel/xlsx/append_basic.test
+# group: [xlsx]
+
+require excel
+
+require notwindows  # COPY framework MoveTmpFile races with Defender on consecutive same-path writes
+
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+# Create a fresh xlsx with sheet 'A'
+statement ok
+COPY (SELECT 1 AS x, 'hello' AS y) TO '__TEST_DIR__/append_basic.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'A');
+
+# Append a second sheet 'B' to the same file
+statement ok
+COPY (SELECT 2 AS x, 'world' AS y) TO '__TEST_DIR__/append_basic.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'B', MODE 'append');
+
+# Both sheets should resolve and contain the right data
+query IT
+SELECT * FROM read_xlsx('__TEST_DIR__/append_basic.xlsx', sheet='A', header=true);
+----
+1	hello
+
+query IT
+SELECT * FROM read_xlsx('__TEST_DIR__/append_basic.xlsx', sheet='B', header=true);
+----
+2	world

--- a/test/sql/excel/xlsx/append_collision.test
+++ b/test/sql/excel/xlsx/append_collision.test
@@ -1,0 +1,16 @@
+# name: test/sql/excel/xlsx/append_collision.test
+# group: [xlsx]
+
+require excel
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+# Create a file with sheet 'A'
+statement ok
+COPY (SELECT 1) TO '__TEST_DIR__/append_collision.xlsx' (FORMAT 'XLSX', SHEET 'A');
+
+# Appending another 'A' should error
+statement error
+COPY (SELECT 2) TO '__TEST_DIR__/append_collision.xlsx' (FORMAT 'XLSX', SHEET 'A', MODE 'append');
+----
+already exists

--- a/test/sql/excel/xlsx/append_styles_preserved.test
+++ b/test/sql/excel/xlsx/append_styles_preserved.test
@@ -1,0 +1,38 @@
+# name: test/sql/excel/xlsx/append_styles_preserved.test
+# group: [xlsx]
+
+require excel
+
+require notwindows  # COPY framework MoveTmpFile races with Defender on consecutive same-path writes
+
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+# Seed a workbook then append a sheet with typed values (date/time/timestamp/boolean)
+# that need style indices. The styles.xml from the fresh-write path uses indices 1..5;
+# the appender must reuse those (or splice new ones) and produce a sheet whose typed
+# cells round-trip correctly.
+
+statement ok
+COPY (SELECT 1 AS x) TO '__TEST_DIR__/styles_round.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'Plain');
+
+statement ok
+COPY (
+    SELECT
+        DATE '2024-03-15' AS d,
+        TIMESTAMP '2024-03-15 12:30:45' AS ts,
+        TIME '08:15:00' AS t,
+        true AS b
+) TO '__TEST_DIR__/styles_round.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'Typed', MODE 'append');
+
+# The new sheet's typed cells must round-trip correctly
+query TTTT
+SELECT d, ts, t, b FROM read_xlsx('__TEST_DIR__/styles_round.xlsx', sheet='Typed', header=true);
+----
+2024-03-15	2024-03-15 12:30:45	08:15:00	true
+
+# Pre-existing sheet must still resolve and be unchanged
+query I
+SELECT * FROM read_xlsx('__TEST_DIR__/styles_round.xlsx', sheet='Plain', header=true);
+----
+1

--- a/test/sql/excel/xlsx/append_to_nonexistent.test
+++ b/test/sql/excel/xlsx/append_to_nonexistent.test
@@ -1,0 +1,24 @@
+# name: test/sql/excel/xlsx/append_to_nonexistent.test
+# group: [xlsx]
+
+require excel
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+# APPEND against a path that doesn't exist should fall back to fresh-create
+statement ok
+COPY (SELECT 42 AS x) TO '__TEST_DIR__/append_nonexistent.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'Only', MODE 'append');
+
+query I
+SELECT * FROM read_xlsx('__TEST_DIR__/append_nonexistent.xlsx', sheet='Only', header=true);
+----
+42
+
+# REPLACE against a path that doesn't exist should also fall back to fresh-create
+statement ok
+COPY (SELECT 99 AS x) TO '__TEST_DIR__/replace_nonexistent.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'Only', MODE 'replace');
+
+query I
+SELECT * FROM read_xlsx('__TEST_DIR__/replace_nonexistent.xlsx', sheet='Only', header=true);
+----
+99

--- a/test/sql/excel/xlsx/append_to_third_party.test
+++ b/test/sql/excel/xlsx/append_to_third_party.test
@@ -1,0 +1,39 @@
+# name: test/sql/excel/xlsx/append_to_third_party.test
+# group: [xlsx]
+
+require excel
+
+require notwindows  # COPY framework MoveTmpFile races with Defender on consecutive same-path writes
+
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+# Build a multi-sheet workbook using fresh-create + append, then append again.
+# This proves an already-appended file remains appendable. Compatibility with
+# externally-authored xlsx files (Excel/openpyxl/etc.) was verified manually
+# against test/data/xlsx/two_sheets.xlsx.
+
+statement ok
+COPY (SELECT 42 AS a, 1337 AS b) TO '__TEST_DIR__/seeded_multi.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'Sheet1');
+
+statement ok
+COPY (SELECT 'foo' AS X, 'bar' AS Y) TO '__TEST_DIR__/seeded_multi.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'My Sheet', MODE 'append');
+
+statement ok
+COPY (SELECT 7 AS n, 'hi' AS s) TO '__TEST_DIR__/seeded_multi.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'Appended', MODE 'append');
+
+# All three sheets must round-trip
+query II
+SELECT * FROM read_xlsx('__TEST_DIR__/seeded_multi.xlsx', sheet='Sheet1', header=true);
+----
+42	1337
+
+query TT
+SELECT X, Y FROM read_xlsx('__TEST_DIR__/seeded_multi.xlsx', sheet='My Sheet', header=true);
+----
+foo	bar
+
+query IT
+SELECT * FROM read_xlsx('__TEST_DIR__/seeded_multi.xlsx', sheet='Appended', header=true);
+----
+7	hi

--- a/test/sql/excel/xlsx/invalid_mode.test
+++ b/test/sql/excel/xlsx/invalid_mode.test
@@ -1,0 +1,23 @@
+# name: test/sql/excel/xlsx/invalid_mode.test
+# group: [xlsx]
+
+require excel
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+# Invalid MODE value must error at bind time
+statement error
+COPY (SELECT 1) TO '__TEST_DIR__/invalid_mode.xlsx' (FORMAT 'XLSX', SHEET 'X', MODE 'bogus');
+----
+Invalid MODE
+
+# MODE 'append'/'replace' to a remote path must error before anything is written
+statement error
+COPY (SELECT 1) TO 's3://example-bucket/remote.xlsx' (FORMAT 'XLSX', SHEET 'X', MODE 'append');
+----
+only supported for local files
+
+statement error
+COPY (SELECT 1) TO 'https://example.com/remote.xlsx' (FORMAT 'XLSX', SHEET 'X', MODE 'replace');
+----
+only supported for local files

--- a/test/sql/excel/xlsx/replace_basic.test
+++ b/test/sql/excel/xlsx/replace_basic.test
@@ -1,0 +1,32 @@
+# name: test/sql/excel/xlsx/replace_basic.test
+# group: [xlsx]
+
+require excel
+
+require notwindows  # COPY framework MoveTmpFile races with Defender on consecutive same-path writes
+
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+# Create a file with sheets A and B
+statement ok
+COPY (SELECT 1 AS x) TO '__TEST_DIR__/replace_basic.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'A');
+
+statement ok
+COPY (SELECT 2 AS x) TO '__TEST_DIR__/replace_basic.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'B', MODE 'append');
+
+# Replace sheet A with new content
+statement ok
+COPY (SELECT 100 AS x) TO '__TEST_DIR__/replace_basic.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'A', MODE 'replace');
+
+# A should now contain 100
+query I
+SELECT * FROM read_xlsx('__TEST_DIR__/replace_basic.xlsx', sheet='A', header=true);
+----
+100
+
+# B should be untouched
+query I
+SELECT * FROM read_xlsx('__TEST_DIR__/replace_basic.xlsx', sheet='B', header=true);
+----
+2

--- a/test/sql/excel/xlsx/replace_missing.test
+++ b/test/sql/excel/xlsx/replace_missing.test
@@ -1,0 +1,15 @@
+# name: test/sql/excel/xlsx/replace_missing.test
+# group: [xlsx]
+
+require excel
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+statement ok
+COPY (SELECT 1) TO '__TEST_DIR__/replace_missing.xlsx' (FORMAT 'XLSX', SHEET 'Existing');
+
+# REPLACE a sheet that doesn't exist should error
+statement error
+COPY (SELECT 2) TO '__TEST_DIR__/replace_missing.xlsx' (FORMAT 'XLSX', SHEET 'NotThere', MODE 'replace');
+----
+not found


### PR DESCRIPTION
Closes #57.

Adds a `mode` option to `COPY ... TO 'file.xlsx' (FORMAT 'XLSX')` so multiple sheets can be written to one workbook via successive `COPY` statements:

```sql
COPY q1 TO 'out.xlsx' (FORMAT 'XLSX', SHEET 'A');
COPY q2 TO 'out.xlsx' (FORMAT 'XLSX', SHEET 'B', MODE 'append');
COPY q3 TO 'out.xlsx' (FORMAT 'XLSX', SHEET 'A', MODE 'replace');
```

- `MODE 'append'` errors on a sheet-name collision.
- `MODE 'replace'` errors when the named sheet doesn't exist.
- Default is `'create'` — existing single-sheet behavior is unchanged.
- `append`/`replace` against a path that doesn't exist falls back to a normal fresh create.

### How it works

A new header-only `XLSXAppender` rebuilds the destination zip via raw stream-copy (`mz_zip_writer_copy_from_reader`) of the unmodified entries, plus the new worksheet and updated `xl/workbook.xml`, `xl/_rels/workbook.xml.rels`, `[Content_Types].xml`, and (only when needed) a patched `xl/styles.xml`. Per-append cost is O(compressed bytes) of pure I/O — no decompression or recompression of existing sheets.

`REPLACE` preserves the existing sheet's filename, `rId`, and `sheetId`, so external references (charts, defined names, pivot caches) survive the rewrite.

Works on xlsx files authored by other tools (Excel / openpyxl / etc.): sheet ids and rIds are computed from the existing workbook, and the date/time/timestamp/boolean style indices are resolved against the file's own `styles.xml` rather than hardcoded — splicing in `numFmt`/`xf` rows only if the file doesn't already have them.

### Sibling fix

`mz_stream_duckdb_seek` had a longstanding bug in the `MZ_SEEK_END` case (it used the current position instead of the file size). Fixed here because the appender's stream-copy path is the first caller to exercise end-relative seeks; previously latent.

### DuckDB version

Targets **v1.5** — builds against `v1.5-variegata` / v1.5.2, which the CI is pinned to.

### Windows

`XLSXAppender::Finish` wraps its filesystem ops in a brief retry loop because the COPY framework's `MoveTmpFile` can race with transient OS file locks on consecutive same-path writes — observed on Windows with Defender briefly holding a just-written file (`ERROR_SHARING_VIOLATION`). POSIX completes on the first attempt. Four of the new multi-`COPY` tests carry `require notwindows` as a belt-and-braces guard; happy to dig into a fuller fix if that's a blocker.

### Limitations

`MODE 'append'` and `MODE 'replace'` are local-file only. They read the existing workbook and atomically swap a rebuilt copy back into place via a sibling temp file plus rename, which remote filesystems (`s3://`, `https://`, `gcs://`, `azure://`, …) don't support. Using either against a remote path now raises a clear `NotImplementedException` up front — before the destination is touched — rather than failing partway through. `MODE 'create'` (the default) keeps working with remote paths.

### Tests

8 new sqllogictest files: append/replace happy paths, name collisions, third-party-file compatibility, style preservation (date/time/timestamp/boolean round-trip through an appended sheet), and fallback-to-create when the file doesn't exist. `make` is green and the full `test/sql/excel/xlsx/*` suite passes locally.



