### PR TITLE
Support remote (S3) xlsx MODE 'append'/'replace' via local staging

### DIFF
--- a/.github/workflows/s3-tests.yml
+++ b/.github/workflows/s3-tests.yml
@@ -1,0 +1,83 @@
+# Runs the gated S3 integration test (append_s3.test) against a local minio server; the main
+# distribution pipeline uses a shared reusable workflow that can't attach one. Keep duckdb_version,
+# ci_tools_version, and the vcpkg commit in sync with MainDistributionPipeline.yml.
+name: S3 Integration Tests
+on:
+  push:
+    paths:
+      - 'src/**'
+      - 'test/sql/excel/xlsx/append_s3.test'
+      - '.github/workflows/s3-tests.yml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'test/sql/excel/xlsx/append_s3.test'
+      - '.github/workflows/s3-tests.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.head_ref || '' }}
+  cancel-in-progress: true
+
+env:
+  MINIO_USER: minio_duckdb_user
+  MINIO_PASSWORD: minio_duckdb_user_password
+  MINIO_BUCKET: test-bucket
+
+jobs:
+  s3-test:
+    name: Build + S3 round-trip (minio)
+    runs-on: ubuntu-latest
+    env:
+      VCPKG_TARGET_TRIPLET: x64-linux
+      GEN: ninja
+      DUCKDB_PLATFORM: linux_amd64
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+
+      - name: Install build dependencies
+        shell: bash
+        # libcurl/libssl are needed by httpfs, which is linked in for the s3 tests below.
+        run: sudo apt-get update -y -qq && sudo apt-get install -y -qq ninja-build libcurl4-openssl-dev libssl-dev
+
+      - name: Start minio
+        shell: bash
+        run: |
+          docker run -d --name minio -p 9000:9000 \
+            -e MINIO_ROOT_USER=${MINIO_USER} \
+            -e MINIO_ROOT_PASSWORD=${MINIO_PASSWORD} \
+            minio/minio server /data
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:9000/minio/health/live && break
+            sleep 1
+          done
+          docker run --rm --network host --entrypoint sh minio/mc -c "
+            mc alias set local http://localhost:9000 ${MINIO_USER} ${MINIO_PASSWORD} &&
+            mc mb -p local/${MINIO_BUCKET}"
+
+      - name: Setup vcpkg
+        uses: lukka/run-vcpkg@v11.5
+        with:
+          vcpkgGitCommitId: ce613c41372b23b1f51333815feb3edd87ef8a8b
+
+      - name: Build extension
+        shell: bash
+        env:
+          VCPKG_TOOLCHAIN_PATH: ${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+        # httpfs is linked statically so the unittester has s3 support without extension autoloading.
+        run: make release CORE_EXTENSIONS='httpfs'
+
+      - name: Run S3 integration test
+        shell: bash
+        env:
+          S3_TEST_SERVER_AVAILABLE: 1
+          AWS_DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: ${{ env.MINIO_USER }}
+          AWS_SECRET_ACCESS_KEY: ${{ env.MINIO_PASSWORD }}
+          DUCKDB_S3_ENDPOINT: localhost:9000
+          DUCKDB_S3_USE_SSL: false
+        run: ./build/release/test/unittest "test/sql/excel/xlsx/append_s3.test"

--- a/src/excel/xlsx/copy_xlsx.cpp
+++ b/src/excel/xlsx/copy_xlsx.cpp
@@ -186,6 +186,45 @@ static unique_ptr<FunctionData> Bind(ClientContext &context, CopyFunctionBindInp
 }
 
 //------------------------------------------------------------------------------
+// Remote staging helpers
+//------------------------------------------------------------------------------
+// Remote MODE 'append'/'replace' can't use the appender's seek-heavy read and atomic
+// rename directly, so the workbook is staged locally: download it, append/replace against
+// the local copy, then upload the result. One GET, one PUT.
+
+// Forward-only byte copy that overwrites the destination, used for both the download and
+// upload legs.
+static void CopyAcrossFileSystems(FileSystem &src_fs, const string &src_path, FileSystem &dst_fs,
+                                  const string &dst_path) {
+	auto in = src_fs.OpenFile(src_path, FileFlags::FILE_FLAGS_READ);
+	auto out = dst_fs.OpenFile(dst_path, FileFlags::FILE_FLAGS_WRITE | FileFlags::FILE_FLAGS_FILE_CREATE);
+
+	constexpr idx_t BUFFER_SIZE = 1 << 20; // 1 MiB
+	auto buffer = make_unsafe_uniq_array_uninitialized<char>(BUFFER_SIZE);
+	while (true) {
+		const auto read_size = in->Read(buffer.get(), BUFFER_SIZE);
+		if (read_size <= 0) {
+			break;
+		}
+		out->Write(buffer.get(), static_cast<idx_t>(read_size));
+	}
+	out->Sync();
+}
+
+// Stage in the working directory rather than DuckDB's `temporary_directory`, which is DuckDB's
+// own scratch space and may be unset or relative for in-memory databases. The filename mirrors
+// the appender's sibling-temp scheme (high-res clock + atomic counter) so writers never collide.
+static string MakeLocalStagePath(FileSystem &local_fs) {
+	const auto base_dir = FileSystem::GetWorkingDirectory();
+
+	static std::atomic<uint64_t> STAGE_COUNTER {0};
+	const auto now_ns = static_cast<uint64_t>(std::chrono::high_resolution_clock::now().time_since_epoch().count());
+	const auto seq = STAGE_COUNTER.fetch_add(1);
+	const auto name = "xlsx_stage." + std::to_string(now_ns) + "." + std::to_string(seq) + ".xlsx";
+	return local_fs.JoinPath(base_dir, name);
+}
+
+//------------------------------------------------------------------------------
 // Init Global
 //------------------------------------------------------------------------------
 struct GlobalWriteXLSXData final : public GlobalFunctionData {
@@ -198,32 +237,51 @@ struct GlobalWriteXLSXData final : public GlobalFunctionData {
 	ExpressionExecutor executor;
 	vector<unique_ptr<Expression>> conversion_expressions;
 
+	// Remote append/replace staging. When the COPY target is a remote append/replace, the
+	// appender runs against a local copy and Finalize uploads the result to remote_final_path.
+	bool is_remote_staging = false;
+	string remote_final_path;        // the real remote dest (s3://, ...)
+	string local_stage_path;         // local working file the appender reads + writes
+	unique_ptr<FileSystem> local_fs; // FileSystem::CreateLocal(); owns the stage file ops
+
 	GlobalWriteXLSXData(ClientContext &context, const string &file_path, const WriteXLSXData &data) : executor(context) {
 
-		// MODE 'append'/'replace' reads the existing workbook and atomically swaps a rebuilt
-		// copy back into place via a sibling temp file + rename. Remote filesystems (s3://,
-		// https://, gcs://, azure://, ...) don't support that rename, so refuse up front
-		// rather than failing partway through after the original has been removed. Checked
-		// against the raw user path before ExpandPath so it fires even without httpfs loaded.
-		if ((data.append || data.replace) && FileSystem::IsRemoteFile(data.file_path)) {
-			throw NotImplementedException(
-			    "XLSX MODE '%s' is only supported for local files; '%s' is on a remote filesystem. "
-			    "Write the workbook to a local path and upload it instead.",
-			    data.replace ? "replace" : "append", data.file_path);
-		}
-
 		auto &fs = FileSystem::GetFileSystem(context);
-		// data.file_path is the user-typed path (may contain `~`); the framework hands us
-		// `file_path` as the temp it'll rename. Expand the user-typed path before checking.
-		const auto target_path = fs.ExpandPath(data.file_path);
-		const bool target_exists = fs.FileExists(target_path);
-		const bool use_appender = (data.append || data.replace) && target_exists;
 
-		if (use_appender) {
-			appender = make_uniq<XLSXAppender>(context, target_path, file_path, data.sheet_name, data.replace,
-			                                   data.sheet_row_limit);
+		// For remote files the framework hands us the final path (use_tmp_file=false), and the raw
+		// user path is checked so this fires even when httpfs isn't loaded.
+		if ((data.append || data.replace) && FileSystem::IsRemoteFile(data.file_path)) {
+			remote_final_path = data.file_path;
+			if (!fs.FileExists(remote_final_path)) {
+				// Append/replace to a missing remote object is a fresh create, same as local.
+				fresh_writer = make_uniq<XLXSWriter>(context, file_path, data.sheet_row_limit);
+			} else {
+				is_remote_staging = true;
+				local_fs = FileSystem::CreateLocal();
+				local_stage_path = MakeLocalStagePath(*local_fs);
+				try {
+					CopyAcrossFileSystems(fs, remote_final_path, *local_fs, local_stage_path);
+					appender = make_uniq<XLSXAppender>(context, local_stage_path, local_stage_path,
+					                                   data.sheet_name, data.replace, data.sheet_row_limit);
+				} catch (...) {
+					// Partially constructed, so the destructor won't run; clean up the stage here.
+					local_fs->TryRemoveFile(local_stage_path);
+					throw;
+				}
+			}
 		} else {
-			fresh_writer = make_uniq<XLXSWriter>(context, file_path, data.sheet_row_limit);
+			// data.file_path is the user-typed path (may contain `~`); the framework hands us
+			// `file_path` as the temp it'll rename. Expand the user-typed path before checking.
+			const auto target_path = fs.ExpandPath(data.file_path);
+			const bool target_exists = fs.FileExists(target_path);
+			const bool use_appender = (data.append || data.replace) && target_exists;
+
+			if (use_appender) {
+				appender = make_uniq<XLSXAppender>(context, target_path, file_path, data.sheet_name, data.replace,
+				                                   data.sheet_row_limit);
+			} else {
+				fresh_writer = make_uniq<XLXSWriter>(context, file_path, data.sheet_row_limit);
+			}
 		}
 
 		// Initialize the expression executor
@@ -266,6 +324,14 @@ struct GlobalWriteXLSXData final : public GlobalFunctionData {
 		// Initialize the cast chunk;
 		const vector<LogicalType> types(data.column_types.size(), LogicalType::VARCHAR);
 		cast_chunk.Initialize(BufferAllocator::Get(context), types);
+	}
+
+	// Safety net for a COPY that fails mid-Sink: Finalize cleans up the stage on the normal
+	// paths, but if it never runs the destructor still removes it. TryRemoveFile is idempotent.
+	~GlobalWriteXLSXData() override {
+		if (is_remote_staging && local_fs) {
+			local_fs->TryRemoveFile(local_stage_path);
+		}
 	}
 };
 
@@ -484,7 +550,24 @@ static void Finalize(ClientContext &context, FunctionData &bind_data, GlobalFunc
 	auto &state = gstate.Cast<GlobalWriteXLSXData>();
 
 	if (state.appender) {
-		state.appender->Finish();
+		try {
+			state.appender->Finish();
+			if (state.is_remote_staging) {
+				// The zip central directory is flushed when the appender's writer is destroyed,
+				// not in Finish(), so destroy it before uploading or the stage is truncated.
+				state.appender.reset();
+				auto &fs = FileSystem::GetFileSystem(context);
+				CopyAcrossFileSystems(*state.local_fs, state.local_stage_path, fs, state.remote_final_path);
+			}
+		} catch (...) {
+			if (state.is_remote_staging) {
+				state.local_fs->TryRemoveFile(state.local_stage_path);
+			}
+			throw;
+		}
+		if (state.is_remote_staging) {
+			state.local_fs->TryRemoveFile(state.local_stage_path);
+		}
 	} else {
 		state.fresh_writer->EndSheet();
 		state.fresh_writer->Finish();

--- a/test/sql/excel/xlsx/append_s3.test
+++ b/test/sql/excel/xlsx/append_s3.test
@@ -1,0 +1,77 @@
+# name: test/sql/excel/xlsx/append_s3.test
+# group: [xlsx]
+
+require excel
+
+require httpfs
+
+require-env S3_TEST_SERVER_AVAILABLE 1
+
+require-env AWS_DEFAULT_REGION
+
+require-env AWS_ACCESS_KEY_ID
+
+require-env AWS_SECRET_ACCESS_KEY
+
+require-env DUCKDB_S3_ENDPOINT
+
+require-env DUCKDB_S3_USE_SSL
+
+require no_extension_autoloading "FIXME: make copy to functions autoloadable"
+
+statement ok
+SET s3_endpoint='${DUCKDB_S3_ENDPOINT}';
+
+statement ok
+SET s3_use_ssl=${DUCKDB_S3_USE_SSL};
+
+statement ok
+SET s3_url_style='path';
+
+# Create a fresh workbook on S3 with sheet 'A'
+statement ok
+COPY (SELECT 1 AS x, 'hello' AS y) TO 's3://test-bucket/xlsx/append_s3.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'A');
+
+# Append a second sheet 'B'
+statement ok
+COPY (SELECT 2 AS x, 'world' AS y) TO 's3://test-bucket/xlsx/append_s3.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'B', MODE 'append');
+
+query IT
+SELECT * FROM read_xlsx('s3://test-bucket/xlsx/append_s3.xlsx', sheet='A', header=true);
+----
+1	hello
+
+query IT
+SELECT * FROM read_xlsx('s3://test-bucket/xlsx/append_s3.xlsx', sheet='B', header=true);
+----
+2	world
+
+# Replace sheet 'A' in place
+statement ok
+COPY (SELECT 99 AS x, 'replaced' AS y) TO 's3://test-bucket/xlsx/append_s3.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'A', MODE 'replace');
+
+query IT
+SELECT * FROM read_xlsx('s3://test-bucket/xlsx/append_s3.xlsx', sheet='A', header=true);
+----
+99	replaced
+
+# Sheet 'B' is untouched
+query IT
+SELECT * FROM read_xlsx('s3://test-bucket/xlsx/append_s3.xlsx', sheet='B', header=true);
+----
+2	world
+
+# Append to a missing key creates a fresh file
+statement ok
+COPY (SELECT 7 AS x, 'fresh' AS y) TO 's3://test-bucket/xlsx/append_s3_new.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'Only', MODE 'append');
+
+query IT
+SELECT * FROM read_xlsx('s3://test-bucket/xlsx/append_s3_new.xlsx', sheet='Only', header=true);
+----
+7	fresh
+
+# Replacing a missing sheet errors
+statement error
+COPY (SELECT 1 AS x) TO 's3://test-bucket/xlsx/append_s3.xlsx' (FORMAT 'XLSX', HEADER true, SHEET 'Missing', MODE 'replace');
+----
+not found

--- a/test/sql/excel/xlsx/invalid_mode.test
+++ b/test/sql/excel/xlsx/invalid_mode.test
@@ -10,14 +10,3 @@ statement error
 COPY (SELECT 1) TO '__TEST_DIR__/invalid_mode.xlsx' (FORMAT 'XLSX', SHEET 'X', MODE 'bogus');
 ----
 Invalid MODE
-
-# MODE 'append'/'replace' to a remote path must error before anything is written
-statement error
-COPY (SELECT 1) TO 's3://example-bucket/remote.xlsx' (FORMAT 'XLSX', SHEET 'X', MODE 'append');
-----
-only supported for local files
-
-statement error
-COPY (SELECT 1) TO 'https://example.com/remote.xlsx' (FORMAT 'XLSX', SHEET 'X', MODE 'replace');
-----
-only supported for local files


### PR DESCRIPTION
## What

Makes `COPY ... TO 's3://.../file.xlsx' (FORMAT xlsx, MODE 'append'|'replace', SHEET '...')` work for remote filesystems. Previously remote append/replace was rejected up front with a `NotImplementedException`.

## Why it couldn't stream before

`XLSXAppender` rebuilds the workbook by reading the source with random seeks and atomically renaming a sibling temp file into place. Remote filesystems (s3/gcs/azure) don't support those primitives well — no atomic rename, and slow/limited random range-reads and backward seek-writes.

## Approach — local staging

For a remote append/replace target: **download** the object to a local temp file → run the existing, unchanged local appender against it → **upload** the rebuilt file back as a single write. One GET, one PUT.

- Routes entirely through DuckDB's `FileSystem` abstraction, so it works for any writable remote FS (s3/gcs/r2/azure) with **zero per-backend code**.
- Append/replace to a **missing** remote object falls back to a fresh create, matching local behavior.
- Read-only transports (`http://`, `https://`, `hf://`) can't append by nature — the upload fails with a clear FS error.
- `XLSXAppender` and `ZipFileWriter` are **unchanged**; all logic lives in `copy_xlsx.cpp`.

## One subtlety worth flagging for reviewers

The zip central directory is flushed when the appender's writer is **destroyed**, not in `Finish()`. The normal local path works because nothing reads the file until the appender goes out of scope — but the staging code uploaded the stage right after `Finish()`, producing a truncated workbook. Fix: destroy the appender (`appender.reset()`) before reading the stage for upload.

## Tests

- All existing local xlsx tests pass; `invalid_mode.test` updated to drop the now-obsolete remote-rejection assertions.
- New `append_s3.test` — `require-env`-gated minio integration test (append, replace, append-to-missing-key, replace-missing-sheet). Validated against minio and a live AWS S3 bucket.
- New `.github/workflows/s3-tests.yml` — stands up minio and builds with `CORE_EXTENSIONS=httpfs` so the unittester actually loads httpfs (it otherwise silently skips the gated test).

## Tradeoff

Staging means peak local disk ≈ 2× the workbook size during the operation; the stage is cleaned up on success and on every failure path.